### PR TITLE
Corrected logging string typo

### DIFF
--- a/jade/configuration.py
+++ b/jade/configuration.py
@@ -69,7 +69,7 @@ class Configuration:
             if not os.path.exists(file_path):
                 # If to terminate or not the session is lef to the user
                 # other codes path may be present but not used
-                logging.warning("Path {file_path} do not exist")
+                logging.warning(f"Path {file_path} do not exist")
                 # fatal_exception(file_path + ' does not exist')
 
         return file_path


### PR DESCRIPTION
Corrected a missing f string definition. 

Might consider using the logging string variable definition as this can come up as a warning in the linter but would have to be consistent across all logging. Here the solution would be 

`logging.warning("Path %s do not exist", file_path)`

See https://docs.python.org/3/howto/logging.html#logging-variable-data and https://docs.python.org/3/howto/logging-cookbook.html#formatting-styles for details.