### PR TITLE
Sphere test fixes

### DIFF
--- a/jade/sphereoutput.py
+++ b/jade/sphereoutput.py
@@ -450,7 +450,7 @@ class SphereOutput(BenchmarkOutput):
         # stat_checks = []
         outputs = {}
         # test_path_openmc = os.path.join(self.test_path, "openmc")
-        for folder in os.listdir(self.test_path):
+        for folder in sorted(os.listdir(self.test_path)):
             results_path = os.path.join(self.test_path, folder, "openmc")
             pieces = folder.split("_")
             # Get zaid

--- a/jade/sphereoutput.py
+++ b/jade/sphereoutput.py
@@ -365,7 +365,7 @@ class SphereOutput(BenchmarkOutput):
         stat_checks = []
         outputs = {}
         # test_path_mcnp = os.path.join(self.test_path, "mcnp")
-        for folder in os.listdir(self.test_path):
+        for folder in sorted(os.listdir(self.test_path)):
             results_path = os.path.join(self.test_path, folder, "mcnp")
             pieces = folder.split("_")
             # Get zaid

--- a/tests/sphereoutput_test.py
+++ b/tests/sphereoutput_test.py
@@ -119,8 +119,8 @@ class TestSphereOutput:
         tally_errors = outputs['M10'].tallydata['Error']        
         assert 0.827104 == pytest.approx(tally_values[10])
         assert 0.000227628 == pytest.approx(tally_errors[176])
-        assert 0.10131285308571429 == pytest.approx(errors[0]['Neutron Spectra'])
-        assert 'M10' == results[0]['Zaid']
+        assert 0.10131285308571429 == pytest.approx(errors[1]['Neutron Spectra'])
+        assert 'M10' == results[1]['Zaid']
 
 # Files
 OUTP_SDDR = os.path.join(

--- a/tests/sphereoutput_test.py
+++ b/tests/sphereoutput_test.py
@@ -108,8 +108,8 @@ class TestSphereOutput:
         tally_errors = outputs['M10'].tallydata['Error']
         assert 3.80420E-07 == pytest.approx(tally_values[10])
         assert 0.0406 == pytest.approx(tally_errors[175])
-        assert 0.6213346456692914 == pytest.approx(errors[0]['Neutron Flux at the external surface in Vitamin-J 175 energy groups'])
-        assert 'M10' == results[0]['Zaid']
+        assert 0.6213346456692914 == pytest.approx(errors[1]['Neutron Flux at the external surface in Vitamin-J 175 energy groups'])
+        assert 'M10' == results[1]['Zaid']
         assert stat_checks[1]['Gamma flux at the external surface [22]'] == 'Missed'
 
     def test_read_openmc_output(self, session_mock: MockUpSession):       

--- a/tests/sphereoutput_test.py
+++ b/tests/sphereoutput_test.py
@@ -108,8 +108,8 @@ class TestSphereOutput:
         tally_errors = outputs['M10'].tallydata['Error']
         assert 3.80420E-07 == pytest.approx(tally_values[10])
         assert 0.0406 == pytest.approx(tally_errors[175])
-        assert 0.6213346456692914 == pytest.approx(errors[1]['Neutron Flux at the external surface in Vitamin-J 175 energy groups'])
-        assert 'M10' == results[1]['Zaid']
+        assert 0.6213346456692914 == pytest.approx(errors[0]['Neutron Flux at the external surface in Vitamin-J 175 energy groups'])
+        assert 'M10' == results[0]['Zaid']
         assert stat_checks[1]['Gamma flux at the external surface [22]'] == 'Missed'
 
     def test_read_openmc_output(self, session_mock: MockUpSession):       
@@ -119,8 +119,8 @@ class TestSphereOutput:
         tally_errors = outputs['M10'].tallydata['Error']        
         assert 0.827104 == pytest.approx(tally_values[10])
         assert 0.000227628 == pytest.approx(tally_errors[176])
-        assert 0.10131285308571429 == pytest.approx(errors[1]['Neutron Spectra'])
-        assert 'M10' == results[1]['Zaid']
+        assert 0.10131285308571429 == pytest.approx(errors[0]['Neutron Spectra'])
+        assert 'M10' == results[0]['Zaid']
 
 # Files
 OUTP_SDDR = os.path.join(


### PR DESCRIPTION
# Description

Tests are looking at inconsistent outputs across platforms. implemented fix through sorting the outputs in the read output methods for mcpn and openmc but this might need rethinking and using actual dictionary's as noted in the docstrings.

Fixes #266 

Additional dependencies introduced.
- N/A

## Type of change

Please select what type of change this is.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New benchmark
    - [ ] Non-breaking change which entirely uses exisiting classes, structure etc
    - [ ] Breaking change which has implemented new/modified classes etc
- [ ] New feature 
    - [ ] Non-breaking change which adds functionality
    - [ ] Breaking change fix or feature that would cause existing functionality to not work as expected

## Other changes

- [x] This change requires a documentation update
- [ ] (If Benchmark) This requires additional data that can be obtained from:
    - Benchmark data 1
    - Benchamrk data 2

# Testing

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Ran pytest locally and successful on CI/CD of fork.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] General testing 
    - [x] New and existing unit tests pass locally with my changes
    - [ ] Coverage is >80%