### PR TITLE
 Hotfix - C-model post-processing

### DIFF
--- a/jade/output.py
+++ b/jade/output.py
@@ -329,8 +329,14 @@ class BenchmarkOutput(AbstractOutput):
                     except KeyError:
                         # this means that the column is only one and we have
                         # two distinct DFs for values and errors
+                        # depending on pandas version, these may be series or
+                        # directly arrays     
                         values = vals_df["Value"]
                         error = err_df["Error"]
+                        if isinstance(values, pd.Series) or isinstance(values, pd.DataFrame):
+                            values = values.values
+                        if isinstance(error, pd.Series) or isinstance(error, pd.DataFrame):
+                            error = error.values
 
                     lib_name = self.session.conf.get_lib_name(self.lib)
                     lib = {"x": x, "y": values, "err": error, "ylabel": lib_name}


### PR DESCRIPTION
# Description

This is an hotfix for the C-model post-processing (more in general for all grouped bars plots). 

It fixes issue #287 that is generated by only newer python versions.

## Type of change

Please select what type of change this is.

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New benchmark
    - [ ] Non-breaking change which entirely uses exisiting classes, structure etc
    - [ ] Breaking change which has implemented new/modified classes etc
- [ ] New feature 
    - [ ] Non-breaking change which adds functionality
    - [ ] Breaking change fix or feature that would cause existing functionality to not work as expected

# Testing

Post-processing of C-Model now runs correctly.


# Checklist:

- [x ] My code follows the style guidelines of this project
- [x ] I have performed a self-review of my code
- [x ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation -> not needed
- [ x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works -> not needed
- [ x] General testing 
    - [ x] New and existing unit tests pass locally with my changes
    - [ x] Coverage is >80%