### PR TITLE
f strings instead of string addition for compact readable code

### DIFF
--- a/jade/status.py
+++ b/jade/status.py
@@ -395,17 +395,7 @@ class Status:
                     logtext = "\nThe following test results have been overwritten:"
                     for code, test_runned in all_test_runned.items():
                         for test in test_runned:
-                            logtext = (
-                                logtext
-                                + "\n"
-                                + "- "
-                                + code
-                                + ": "
-                                + test
-                                + " ["
-                                + lib
-                                + "]"
-                            )
+                            logtext += f"\n- {code}: {test} [{lib}]"
                     session.log.adjourn(logtext)
                     return True
 

--- a/jade/utilitiesgui.py
+++ b/jade/utilitiesgui.py
@@ -811,13 +811,7 @@ def print_XS_EXFOR(session):
                         bookXS[j][MT] = bookXS[j]["dataT"].reactions[i]
                     # Don't print if MT is not present in library
                     except KeyError:
-                        s = (
-                            "Channel MT"
-                            + str(i)
-                            + " "
-                            + "not present in "
-                            + bookXS[j]["name"]
-                        )
+                        s = f"Channel MT{i} not present in {bookXS[j]['name']}"
                         print(s)
                         continue
 
@@ -957,7 +951,7 @@ def print_XS_EXFOR(session):
             )
             plt.savefig(
                 os.path.join(
-                    session.path_uti, isotope_name + "_" + MT + "_" + "XS" + ".png"
+                    session.path_uti, f"{isotope_name}_{MT}_XS.png"
                 )
             )
             print(" Cross Section printed")


### PR DESCRIPTION
# Description

I've noticed the use of ```+``` to combine strings together in many places in the code so I wanted to make an example of how we can do this withf strings instead. In this case I think the f string version of code is a little nicer to read than the addition version. I've also made use of ```+=```

Fixes # (issue)

nothing 

Additional dependencies introduced.

None

## Type of change

Please select what type of change this is.

- [ ] refactoring for readability

## Other changes

- [ ] This change requires a documentation update
- [ ] (If Benchmark) This requires additional data that can be obtained from:
    - Benchmark data 1
    - Benchamrk data 2

# Testing

Sorry I've checked the output is the same locally but not added tests for this small change

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] General testing 
    - [ ] New and existing unit tests pass locally with my changes
    - [ ] Coverage is >80%