### PR TITLE
fix standard deviation sheet

### DIFF
--- a/jade/sphereoutput.py
+++ b/jade/sphereoutput.py
@@ -725,7 +725,9 @@ class SphereOutput(BenchmarkOutput):
                 idx2 = error_dfs[0].index
                 newidx = idx1.intersection(idx2)
 
-                std_dev = absdiff.loc[newidx] / error_dfs[0].loc[newidx]
+                std_dev = absdiff.loc[newidx] / (
+                    error_dfs[0].loc[newidx] * comp_dfs[0].loc[newidx]
+                )
 
                 # self.std_dev["mcnp"] = std_dev
                 # Correct sorting
@@ -1837,7 +1839,7 @@ class SphereSDDRoutput(SphereOutput):
         # Build the final excel data
         absdiff = ref - tar
         final = absdiff / ref
-        std_dev = absdiff / ref_err
+        std_dev = absdiff / (ref_err * ref)
 
         # If it is zero the CS are equal! (NaN if both zeros)
         for df in [final, absdiff, std_dev]:


### PR DESCRIPTION
# Description

The standard deviation sheet was computed as the absolute difference between the results (reference-target) divided by the relative error value of the reference.  The actual quantity of interest here is instead the absolute difference divided by the product of ref error times ref value in order to divide by the absolute error. This small PR fixes this issue in the Sphere and SphereSDDR benchmarks. 

## Type of change

Please select what type of change this is.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New benchmark
    - [ ] Non-breaking change which entirely uses exisiting classes, structure etc
    - [ ] Breaking change which has implemented new/modified classes etc
- [x] New feature 
    - [x] Non-breaking change which adds functionality
    - [ ] Breaking change fix or feature that would cause existing functionality to not work as expected
