### PR TITLE
Add Codecov support for better code coverage tracking

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -57,7 +57,7 @@ jobs:
         run: |
           set -o pipefail
           source /usr/local/Modules/init/sh
-          pytest --cov=. --cov-report html -cov-config=jade.coveragerc --cov-report xml
+          pytest --cov=. -cov-config=jade.coveragerc --cov-report xml
         env:
           ACCESS_TOKEN_GITHUB: ${{ secrets.ACCESS_TOKEN_GITHUB }}
 

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -57,7 +57,7 @@ jobs:
         run: |
           set -o pipefail
           source /usr/local/Modules/init/sh
-          pytest --cov=. --cov-report html -cov-config=jade.coveragerc | tee pytest_output.log
+          pytest --cov=. --cov-report html -cov-config=jade.coveragerc --cov-report xml
         env:
           ACCESS_TOKEN_GITHUB: ${{ secrets.ACCESS_TOKEN_GITHUB }}
 
@@ -65,20 +65,16 @@ jobs:
       - name: Testing - Windows
         if: runner.os == 'Windows'
         run: |
-          pytest --cov=. --cov-report html -cov-config="jade.coveragerc" | tee pytest_output.log
+          pytest
         env:
           ACCESS_TOKEN_GITHUB: ${{ secrets.ACCESS_TOKEN_GITHUB }}
-
-      - name: Archive test results
-        if: always()
-        uses: actions/upload-artifact@v4
+      
+      # Upload coverage to Codecov. Do it only for one case of the matrix.
+      - name: Upload coverage to Codecov
+        # do it only once for python 3.10
+        if: matrix.python-version == '3.11' && matrix.os == 'ubuntu-latest'
+        uses: codecov/codecov-action@v4
         with:
-          name: pytest_output_${{matrix.os}}_${{matrix.python-version}}.log
-          path: pytest_output.log
-
-      - name: Archive test coverage
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: htmlcov${{matrix.os}}_${{matrix.python-version}}
-          path: htmlcov/
+          verbose: true
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![Testing](https://github.com/JADE-V-V/JADE/actions/workflows/pytest.yml/badge.svg?branch=master)](https://github.com/JADE-V-V/JADE/actions/workflows/pytest.yml)
 [![Documentation Status](https://readthedocs.org/projects/jade-a-nuclear-data-libraries-vv-tool/badge/?version=latest)](https://jade-a-nuclear-data-libraries-vv-tool.readthedocs.io/en/latest/?badge=latest)
+[![codecov](https://codecov.io/gh/JADE-V-V/JADE/graph/badge.svg?token=C0Q75M9FVH)](https://codecov.io/gh/JADE-V-V/JADE)
 
 <img src="https://user-images.githubusercontent.com/25747626/118662537-5f124900-b7f0-11eb-8d69-282305f795c4.png" width="300" />
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,3 @@
+# sample regex patterns
+ignore:
+  - "tests"  # ignore folders and all its contents

--- a/jade.coveragerc
+++ b/jade.coveragerc
@@ -2,9 +2,9 @@
 [run]
 omit =
     # No need to cover the test files
-    tests/*
+    */tests/*
     # The following are not developed directly by JADE
-    MCTAL_READER2.py
-    xsdirpyne.py
+    */MCTAL_READER2.py
+    */xsdirpyne.py
 [html]
 show_contexts = True


### PR DESCRIPTION
# Description

Code coverage is very important for a software like JADE that is used as V&V tool itself. This PR connects JADE to Codecov in order to get coverage results in CI for easier monitoring with respect to current method which computes the coverage reports and hosts them on the GitHub actions as artifacts.

Fixes #314 

## Type of change

Please select what type of change this is.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New benchmark
    - [ ] Non-breaking change which entirely uses exisiting classes, structure etc
    - [ ] Breaking change which has implemented new/modified classes etc
- [x] New feature 
    - [x] Non-breaking change which adds functionality
    - [ ] Breaking change fix or feature that would cause existing functionality to not work as expected

# Testing

N.A.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] General testing 
    - [ ] New and existing unit tests pass locally with my changes
    - [ ] Coverage is >80%