### PR TITLE
scipy version fix

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -29,6 +29,8 @@ install_requires =
     xlsxwriter
     openpyxl
     matplotlib
+    # Latest version of scipy that supports Python 3.9.
+    # This is a temporary fix and should be removed once Python 3.9 support is dropped in JADE. 
     scipy == 1.13.1
     python-docx
     aspose-words

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ install_requires =
     xlsxwriter
     openpyxl
     matplotlib
-    scipy
+    scipy == 1.13.1
     python-docx
     aspose-words
     requests


### PR DESCRIPTION
# Description

There is a bug in openmc python install for version 0.14.0 due to incompatability of scipy versions. The scipy version needs to be fixed to the latest one that carries support for 3.9.

We can consider going to v0.15.0 of openmc which works OK with no fixed scipy version however the requirement for this is >=3.10. Currently JADE supports >=3.9.

Fixes # (issue)

Additional dependencies introduced.
- Existing dependency scipy version fixed. 

## Type of change

Please select what type of change this is.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New benchmark
    - [ ] Non-breaking change which entirely uses exisiting classes, structure etc
    - [ ] Breaking change which has implemented new/modified classes etc
- [ ] New feature 
    - [ ] Non-breaking change which adds functionality
    - [ ] Breaking change fix or feature that would cause existing functionality to not work as expected

## Other changes

- [ ] This change requires a documentation update
- [ ] (If Benchmark) This requires additional data that can be obtained from:
    - Benchmark data 1
    - Benchamrk data 2

# Testing

N.A.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] General testing 
    - [ ] New and existing unit tests pass locally with my changes
    - [ ] Coverage is >80%