### PR TITLE
Statepoint output file support for OMC Sphere benchmark

### DIFF
--- a/jade/openmc.py
+++ b/jade/openmc.py
@@ -2,6 +2,7 @@ import logging
 import os
 import re
 import openmc
+import inspect
 
 
 class OpenMCInputFiles:
@@ -125,11 +126,10 @@ class OpenMCInputFiles:
 
 
 class OpenMCOutput:
-
     def __init__(self, spfile_path: str) -> None:
         self.initialise(spfile_path)
         self.version = self.read_openmc_version()
-
+   
     def initialise(self, spfile_path: str) -> None:
         """Read in statepoint file
 
@@ -161,17 +161,18 @@ class OpenMCOutput:
 
 class OpenMCSphereOutput(OpenMCOutput):
     def __init__(self, spfile_path: str) -> None:
-        super.__init__(self, spfile_path)
+        super().__init__(spfile_path)
 
     def _get_tally_data(self, rows: list, filter: openmc.Filter):
         tally = self.statepoint.get_tally(filters=[filter])
-        tally_n = tally.tally_id
+        tally_n = tally.id
         tally_description = tally.name
         energy_bins = tally.find_filter(openmc.EnergyFilter).values[1:]
-        fluxes = tally.mean
-        errors = tally.std_dev
+        fluxes = tally.mean.flatten()
+        errors = tally.std_dev.flatten()
         for energy, flux, error in zip(energy_bins, fluxes, errors):
-            rows.append([tally_n, tally_description,energy, flux, error])
+            rows.append([tally_n, tally_description, energy, flux, error])
+        return rows
     
     def tally_to_rows(self):
         rows = []

--- a/jade/openmc.py
+++ b/jade/openmc.py
@@ -158,3 +158,31 @@ class OpenMCOutput:
         """
         version = ".".join(map(str, self.statepoint.version))
         return version
+
+class OpenMCSphereOutput(OpenMCOutput):
+    def __init__(self, spfile_path: str) -> None:
+        super.__init__(self, spfile_path)
+
+    def _get_tally_data(self, rows: list, filter: openmc.Filter):
+        tally = self.statepoint.get_tally(filters=[filter])
+        tally_n = tally.tally_id
+        tally_description = tally.name
+        energy_bins = tally.find_filter(openmc.EnergyFilter).values[1:]
+        fluxes = tally.mean
+        errors = tally.std_dev
+        for energy, flux, error in zip(energy_bins, fluxes, errors):
+            rows.append([tally_n, tally_description,energy, flux, error])
+    
+    def tally_to_rows(self):
+        rows = []
+        neutron_particle_filter = openmc.ParticleFilter(['neutron'])
+        rows = self._get_tally_data(rows, neutron_particle_filter)
+        photon_particle_filter = openmc.ParticleFilter(['photon'])
+        rows = self._get_tally_data(rows, photon_particle_filter)
+        return rows
+
+
+
+
+
+    

--- a/jade/openmc.py
+++ b/jade/openmc.py
@@ -2,8 +2,6 @@ import logging
 import os
 import re
 import openmc
-import inspect
-
 
 class OpenMCInputFiles:
     def __init__(self, path: str, name=None) -> None:
@@ -166,7 +164,7 @@ class OpenMCSphereOutput(OpenMCOutput):
     def _get_tally_data(self, rows: list, filter: openmc.Filter):
         tally = self.statepoint.get_tally(filters=[filter])
         tally_n = tally.id
-        tally_description = tally.name
+        tally_description = tally.name.title()
         energy_bins = tally.find_filter(openmc.EnergyFilter).values[1:]
         fluxes = tally.mean.flatten()
         errors = tally.std_dev.flatten()

--- a/jade/openmc.py
+++ b/jade/openmc.py
@@ -3,6 +3,7 @@ import os
 import re
 import openmc
 
+
 class OpenMCInputFiles:
     def __init__(self, path: str, name=None) -> None:
         self.path = path
@@ -127,7 +128,7 @@ class OpenMCOutput:
     def __init__(self, spfile_path: str) -> None:
         self.initialise(spfile_path)
         self.version = self.read_openmc_version()
-   
+
     def initialise(self, spfile_path: str) -> None:
         """Read in statepoint file
 
@@ -157,6 +158,7 @@ class OpenMCOutput:
         version = ".".join(map(str, self.statepoint.version))
         return version
 
+
 class OpenMCSphereOutput(OpenMCOutput):
     def __init__(self, spfile_path: str) -> None:
         super().__init__(spfile_path)
@@ -171,17 +173,11 @@ class OpenMCSphereOutput(OpenMCOutput):
         for energy, flux, error in zip(energy_bins, fluxes, errors):
             rows.append([tally_n, tally_description, energy, flux, error])
         return rows
-    
+
     def tally_to_rows(self):
         rows = []
-        neutron_particle_filter = openmc.ParticleFilter(['neutron'])
+        neutron_particle_filter = openmc.ParticleFilter(["neutron"])
         rows = self._get_tally_data(rows, neutron_particle_filter)
-        photon_particle_filter = openmc.ParticleFilter(['photon'])
+        photon_particle_filter = openmc.ParticleFilter(["photon"])
         rows = self._get_tally_data(rows, photon_particle_filter)
         return rows
-
-
-
-
-
-    

--- a/jade/output.py
+++ b/jade/output.py
@@ -110,11 +110,10 @@ class AbstractOutput(abc.ABC):
                 elif file_name[-1] == "o":
                     file2 = file_name
             elif code == "openmc":
-                if file_name.endswith('.out'):
+                if file_name.endswith(".out"):
                     file1 = file_name
                 elif file_name.startswith("statepoint"):
                     file2 = file_name
-                
 
         if file1 is None or (code == "mcnp" and file2 is None):
             raise FileNotFoundError(
@@ -1182,7 +1181,6 @@ class MCNPoutput:
 class OpenMCOutput:
     def __init__(self, output_path):
         self.output = omc.OpenMCOutput(output_path)
-        #self.output_file_data = self.read(output_file)
         self.tallydata, self.totalbin = self.process_tally()
         self.stat_checks = None
 

--- a/jade/output.py
+++ b/jade/output.py
@@ -167,7 +167,7 @@ class BenchmarkOutput(AbstractOutput):
         # Updated to handle multiple codes
         # initialize them so that intellisense knows they are available
         self.mcnp = False
-        self.d1s = False
+        self.openmc = False
         self.serpent = False
         self.d1s = False
         for available_code in CODES.values():
@@ -1180,9 +1180,9 @@ class MCNPoutput:
 
 
 class OpenMCOutput:
-    def __init__(self, output_file):
-        self.output_file = output_file
-        self.output_file_data = self.read(output_file)
+    def __init__(self, output_path):
+        self.output = omc.OpenMCOutput(output_path)
+        #self.output_file_data = self.read(output_file)
         self.tallydata, self.totalbin = self.process_tally()
         self.stat_checks = None
 

--- a/jade/sphereoutput.py
+++ b/jade/sphereoutput.py
@@ -482,7 +482,7 @@ class SphereOutput(BenchmarkOutput):
             else:
                 zaidname = pieces[-1]
             # Parse output
-            _, outfile = self._get_output_files(results_path, 'openmc')
+            _, outfile = self._get_output_files(results_path, "openmc")
             output = SphereOpenMCoutput(outfile)
             outputs[zaidnum] = output
             # Adjourn raw Data
@@ -874,10 +874,9 @@ class SphereOutput(BenchmarkOutput):
                         for file in os.listdir(results_path):
                             if "tallies.out" in file:
                                 outfile = file
-                        
 
                         # Parse output
-                        _, outfile = self._get_output_files(results_path, 'openmc')
+                        _, outfile = self._get_output_files(results_path, "openmc")
                         output = SphereOpenMCoutput(outfile)
                         outputs_lib[zaidnum] = output
                         res, err, columns = output.get_comparison_data(
@@ -1271,7 +1270,6 @@ class SphereOpenMCoutput(OpenMCOutput, SphereTallyOutput):
         self.tallydata, self.totalbin = self.process_tally()
         self.stat_checks = None
 
-    
     def _create_dataframe(self, rows):
         """Creates dataframe from the data in each output passed through as
         a list of lists from the process_tally function

--- a/jade/sphereoutput.py
+++ b/jade/sphereoutput.py
@@ -482,8 +482,8 @@ class SphereOutput(BenchmarkOutput):
             else:
                 zaidname = pieces[-1]
             # Parse output
-            #output = SphereOpenMCoutput(os.path.join(results_path, "tallies.out"))
-            output = SphereOpenMCoutput(results_path)
+            _, outfile = self._get_output_files(results_path, 'openmc')
+            output = SphereOpenMCoutput(outfile)
             outputs[zaidnum] = output
             # Adjourn raw Data
             self.raw_data["openmc"][zaidnum] = output.tallydata
@@ -874,10 +874,11 @@ class SphereOutput(BenchmarkOutput):
                         for file in os.listdir(results_path):
                             if "tallies.out" in file:
                                 outfile = file
+                        
 
                         # Parse output
-                        #outfile = os.path.join(results_path, outfile)
-                        output = SphereOpenMCoutput(results_path)
+                        _, outfile = self._get_output_files(results_path, 'openmc')
+                        output = SphereOpenMCoutput(outfile)
                         outputs_lib[zaidnum] = output
                         res, err, columns = output.get_comparison_data(
                             ["4", "14"], "openmc"
@@ -1265,6 +1266,12 @@ class SphereMCNPoutput(MCNPoutput, SphereTallyOutput):
 
 
 class SphereOpenMCoutput(OpenMCOutput, SphereTallyOutput):
+    def __init__(self, output_path):
+        self.output = omc.OpenMCSphereOutput(output_path)
+        self.tallydata, self.totalbin = self.process_tally()
+        self.stat_checks = None
+
+    
     def _create_dataframe(self, rows):
         """Creates dataframe from the data in each output passed through as
         a list of lists from the process_tally function

--- a/jade/sphereoutput.py
+++ b/jade/sphereoutput.py
@@ -47,6 +47,11 @@ from jade.output import BenchmarkOutput, OpenMCOutput, MCNPoutput
 if TYPE_CHECKING:
     from jade.main import Session
 
+from jade.__openmc__ import OMC_AVAIL
+
+if OMC_AVAIL:
+    import jade.openmc as omc
+
 
 class SphereOutput(BenchmarkOutput):
     def __init__(self, lib: str, code: str, testname: str, session: Session):
@@ -477,7 +482,8 @@ class SphereOutput(BenchmarkOutput):
             else:
                 zaidname = pieces[-1]
             # Parse output
-            output = SphereOpenMCoutput(os.path.join(results_path, "tallies.out"))
+            #output = SphereOpenMCoutput(os.path.join(results_path, "tallies.out"))
+            output = SphereOpenMCoutput(results_path)
             outputs[zaidnum] = output
             # Adjourn raw Data
             self.raw_data["openmc"][zaidnum] = output.tallydata
@@ -870,8 +876,8 @@ class SphereOutput(BenchmarkOutput):
                                 outfile = file
 
                         # Parse output
-                        outfile = os.path.join(results_path, outfile)
-                        output = SphereOpenMCoutput(outfile)
+                        #outfile = os.path.join(results_path, outfile)
+                        output = SphereOpenMCoutput(results_path)
                         outputs_lib[zaidnum] = output
                         res, err, columns = output.get_comparison_data(
                             ["4", "14"], "openmc"
@@ -1306,6 +1312,7 @@ class SphereOpenMCoutput(OpenMCOutput, SphereTallyOutput):
             totalbin: Dataframe
             see dftotal in _create_dataframe()
         """
+        """
         rows = []
         for line in self.output_file_data:
             if "tally" in line.lower():
@@ -1322,6 +1329,8 @@ class SphereOpenMCoutput(OpenMCOutput, SphereTallyOutput):
                     parts = line.split()
                     value, error = float(parts[1]), float(parts[3])
                     rows.append([tally_n, tally_description, energy, value, error])
+        """
+        rows = self.output.tally_to_rows()
         tallydata, totalbin = self._create_dataframe(rows)
         return tallydata, totalbin
 

--- a/tests/sphereoutput_test.py
+++ b/tests/sphereoutput_test.py
@@ -144,8 +144,8 @@ class TestSphereOutput:
         outputs, results, errors = sphere_00c._read_openmc_output()
         tally_values = outputs["M10"].tallydata["Value"]
         tally_errors = outputs["M10"].tallydata["Error"]
-        assert 0.827104 == pytest.approx(tally_values[10])
-        assert 0.000227628 == pytest.approx(tally_errors[176])
+        assert 0.8271037652370498 == pytest.approx(tally_values[10])
+        assert 0.00022762768783691538 == pytest.approx(tally_errors[176])
         assert 0.10131285308571429 == pytest.approx(errors[1]["Neutron Spectra"])
         assert "M10" == results[1]["Zaid"]
 


### PR DESCRIPTION
# Description

OpenMC output data produced from the Sphere benchmark is now read in from the StatePoint file, using the OpenMC API, rather than the tallies.out file.

## Type of change

Please select what type of change this is.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New benchmark
    - [ ] Non-breaking change which entirely uses exisiting classes, structure etc
    - [ ] Breaking change which has implemented new/modified classes etc
- [ ] New feature 
    - [x] Non-breaking change which adds functionality
    - [ ] Breaking change fix or feature that would cause existing functionality to not work as expected

## Other changes

- [ ] This change requires a documentation update
- [ ] (If Benchmark) This requires additional data that can be obtained from:
    - Benchmark data 1
    - Benchamrk data 2

# Testing

Numerical tests in sphereoutput_test.py relating to OpenMC have been updated to reflect the increased precision of numerical outputs from the statepoint file compared with the .out file. 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] General testing 
    - [x] New and existing unit tests pass locally with my changes
    - [x] Coverage is >80%