### PR TITLE
Unix module fix

### DIFF
--- a/jade/unix.py
+++ b/jade/unix.py
@@ -26,18 +26,18 @@ import re
 import subprocess
 import sys
 
-if "MODULEPATH" not in os.environ and "win" not in sys.platform:
-    f = open(os.environ["MODULESHOME"] + "/init/.modulespath", "r")
-    path = []
-    for line in f.readlines():
-        line = re.sub("#.*$", "", line)
-        if line != "":
-            path.append(line)
-    os.environ["MODULEPATH"] = ":".join(path)
+if "MODULESHOME" in os.environ:
+    if "MODULEPATH" not in os.environ and "win" not in sys.platform:
+        f = open(os.environ["MODULESHOME"] + "/init/.modulespath", "r")
+        path = []
+        for line in f.readlines():
+            line = re.sub("#.*$", "", line)
+            if line != "":
+                path.append(line)
+        os.environ["MODULEPATH"] = ":".join(path)
 
-if "LOADEDMODULES" not in os.environ and "win" not in sys.platform:
-    os.environ["LOADEDMODULES"] = ""
-
+    if "LOADEDMODULES" not in os.environ and "win" not in sys.platform:
+        os.environ["LOADEDMODULES"] = ""
 
 def module(*args: list) -> None:
     """Runs the module command using subprocess"""


### PR DESCRIPTION
# Description

A fix to unix.py, to catch an exception found for WSL Ubuntu installations. Previously JADE would not run on WSL Ubuntu.

## Type of change

Please select what type of change this is.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New benchmark
    - [ ] Non-breaking change which entirely uses exisiting classes, structure etc
    - [ ] Breaking change which has implemented new/modified classes etc
- [ ] New feature 
    - [ ] Non-breaking change which adds functionality
    - [ ] Breaking change fix or feature that would cause existing functionality to not work as expected

## Other changes

- [ ] This change requires a documentation update
- [ ] (If Benchmark) This requires additional data that can be obtained from:
    - Benchmark data 1
    - Benchamrk data 2

# Testing

Local jade initialization now works on Ubuntu WSL.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] General testing 
    - [x] New and existing unit tests pass locally with my changes
    - [x] Coverage is >80%