### PR TITLE
Connect F4E gitlab to JADE

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -71,6 +71,8 @@ jobs:
           pytest --cov=. -cov-config=jade.coveragerc --cov-report xml
         env:
           ACCESS_TOKEN_GITHUB: ${{ secrets.ACCESS_TOKEN_GITHUB }}
+          F4E_GITLAB_TOKEN: ${{ secrets.F4E_GITLAB_TOKEN }}
+
 
       # Activate environment and run pytest
       - name: Testing - Windows
@@ -79,6 +81,7 @@ jobs:
           pytest
         env:
           ACCESS_TOKEN_GITHUB: ${{ secrets.ACCESS_TOKEN_GITHUB }}
+          F4E_GITLAB_TOKEN: ${{ secrets.F4E_GITLAB_TOKEN }}
       
       # Upload coverage to Codecov. Do it only for one case of the matrix.
       - name: Upload coverage to Codecov

--- a/.gitignore
+++ b/.gitignore
@@ -23,4 +23,4 @@ venv/*
 .vscode/
 
 # secret file for local testing
-tests/secrets.json
+secrets.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,8 @@ dependencies = [
 #    openmc @ git+https://github.com/openmc-dev/openmc.git@v0.14.0#egg=openmc
     "pyyaml",
     "ttkthemes",
-    "seaborn"
+    "seaborn",
+    "python-gitlab"
 ]
 [project.optional-dependencies]
 dev = [

--- a/src/jade/app/app.py
+++ b/src/jade/app/app.py
@@ -12,7 +12,7 @@ from tqdm import tqdm
 
 import jade.resources as res
 from jade import resources
-from jade.app.fetch import fetch_iaea_inputs
+from jade.app.fetch import fetch_f4e_inputs, fetch_iaea_inputs
 from jade.config.paths_tree import PathsTree
 from jade.config.pp_config import PostProcessConfig
 from jade.config.raw_config import ConfigRawProcessor
@@ -92,7 +92,19 @@ class JadeApp:
             self.tree.benchmark_input_templates, self.tree.exp_data
         )
         if not success:
-            logging.error("Failed to update the benchmark inputs.")
+            logging.error("Failed to update the IAEA benchmark inputs.")
+
+        f4e_gitlab_token = self.run_cfg.env_vars.f4e_gitlab_token
+        if f4e_gitlab_token is not None:
+            success = fetch_f4e_inputs(
+                self.tree.benchmark_input_templates,
+                self.tree.exp_data,
+                f4e_gitlab_token,
+            )
+            if not success:
+                logging.error("Failed to update the F4E benchmark inputs.")
+        else:
+            logging.info("No F4E token found. Skipping F4E inputs update.")
 
     def restore_default_cfg(self, msg: str = ""):
         """Reset the configuration files to installation default. The session

--- a/src/jade/app/fetch.py
+++ b/src/jade/app/fetch.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
+import logging
 import os
 import shutil
 import tempfile
 import zipfile
 from pathlib import Path
 
+import gitlab
 import requests
 
 from jade.helper.aux_functions import PathLike
@@ -14,7 +16,9 @@ BRANCH = "jadev4"  # TODO change in main once merged the PR
 IAEA_URL = f"https://github.com/IAEA-NDS/open-benchmarks/archive/{BRANCH}.zip"
 
 
-def _fetch_from_git(url: str, authorization_token: str | None = None) -> str | bool:
+def _fetch_from_git(
+    url: str, authorization_token: str | None = None
+) -> PathLike | bool:
     """Download a repository from GitHub/GitLab and extract
     it to a temporary folder. It can also deal with authentication.
 
@@ -44,16 +48,64 @@ def _fetch_from_git(url: str, authorization_token: str | None = None) -> str | b
     if response.status_code != 200:
         return False
     # Save the downloaded zip file
+    extracted_folder = _extract_zip(response.content, os.path.basename(url))
+    return extracted_folder
+
+
+def _extract_zip(zip_content, dest: PathLike) -> PathLike:
     tmpdirname = tempfile.gettempdir()
-    tmp_zip = os.path.join(tmpdirname, os.path.basename(url))
+    tmp_zip = os.path.join(tmpdirname, dest)
     extracted_folder = os.path.join(tmpdirname, "extracted")
     with open(tmp_zip, "wb") as f:
-        f.write(response.content)
+        f.write(zip_content)
     # Extract the zip file
     with zipfile.ZipFile(tmp_zip, "r") as zip_ref:
+        main_folder_name = zip_ref.namelist()[0]
         zip_ref.extractall(extracted_folder)
 
-    return extracted_folder
+    return Path(extracted_folder, main_folder_name)
+
+
+def fetch_from_gitlab(
+    url: str, path: str, branch: str, authorization_token: str = None
+) -> PathLike | bool:
+    """Download a repository from GitLab and extract
+    it to a temporary folder. It can also deal with authentication. Supported
+    authentication is by token.
+    Parameters
+    ----------
+    url : str
+        path to the gitlab website (e.g. https://git.oecd-nea.org/)
+    path : str
+        path to the repository (e.g. /sinbad/sinbad.v2/sinbad-version-2-volume-1/FUS-ATN-BLK-STR-PNT-001-FNG-Osaka-Aluminium-Sphere-OKTAVIAN-oktav_al)
+    branch : str, optional
+        Branch to download. Default is jade.
+    authorization_token : str, optional
+        Authorization token to access the IAEA repository. Default is None.
+    Returns
+    -------
+    extracted_folder: Pathlike | bool
+        path to the extracted folder. False if the download was not successful.
+    """
+    gl = gitlab.Gitlab(url=url, private_token=authorization_token, ssl_verify=False)
+    try:
+        gl.auth()
+    except gitlab.exceptions.GitlabAuthenticationError:
+        logging.error("Gitlab authentication failed")
+        return False
+
+    # select the correct project
+    found = False
+    for project in gl.projects.list():
+        if path == project.path_with_namespace:
+            found = True
+            break
+    if not found:
+        logging.error(f"Successful authentication but project {path} not found")
+        return False
+
+    binary = project.repository_archive(sha=branch, format="zip")
+    return _extract_zip(binary, os.path.basename(path) + ".zip")
 
 
 def _install_data(fetch_folder: str | os.PathLike, install_folder: str | os.PathLike):
@@ -68,6 +120,28 @@ def _install_data(fetch_folder: str | os.PathLike, install_folder: str | os.Path
             os.path.join(fetch_folder, item),
             os.path.join(install_folder, item),
         )
+
+
+def _install_standard_folder_structure(
+    extracted_folder: str | os.PathLike,
+    inputs_root: PathLike,
+    exp_data_root: PathLike,
+    path_to_inputs: str | os.PathLike,
+    path_to_exp_data: str | os.PathLike,
+) -> bool:
+    if isinstance(extracted_folder, bool):
+        return False
+
+    for fetched_folder, install_folder in [
+        (path_to_inputs, inputs_root),
+        (path_to_exp_data, exp_data_root),
+    ]:
+        _install_data(fetched_folder, install_folder)
+
+    # Once done, delete the src folder
+    shutil.rmtree(extracted_folder)
+
+    return True
 
 
 def fetch_iaea_inputs(inputs_root: PathLike, exp_data_root: PathLike) -> bool:
@@ -87,24 +161,55 @@ def fetch_iaea_inputs(inputs_root: PathLike, exp_data_root: PathLike) -> bool:
     bool
         True if the inputs were successfully fetched, False otherwise.
     """
-    extracted_folder = _fetch_from_git(IAEA_URL)  # no token required anymore
-    if isinstance(extracted_folder, bool):
-        return False
+    extracted_folder = str(_fetch_from_git(IAEA_URL))  # no token required anymore
 
-    path_to_inputs = Path(
-        extracted_folder, f"open-benchmarks-{BRANCH}", "jade_open_benchmarks", "inputs"
-    )
-    path_to_exp_data = os.path.join(
+    path_to_inputs = Path(extracted_folder, "jade_open_benchmarks", "inputs")
+    path_to_exp_data = Path(
         extracted_folder,
-        f"open-benchmarks-{BRANCH}",
         "jade_open_benchmarks",
         "exp_results",
     )
+    success = _install_standard_folder_structure(
+        extracted_folder, inputs_root, exp_data_root, path_to_inputs, path_to_exp_data
+    )
+    return success
 
-    for fetched_folder, install_folder in [
-        (path_to_inputs, inputs_root),
-        (path_to_exp_data, exp_data_root),
-    ]:
-        _install_data(fetched_folder, install_folder)
 
-    return True
+def fetch_f4e_inputs(
+    inputs_root: PathLike, exp_data_root: PathLike, access_token: str
+) -> bool:
+    """Fetch F4E benchmark inputs and experimental data and copy them to
+    the correct folder in jade structure. This will always override the available
+    data.
+
+    Parameters
+    ----------
+    inputs_root : PathLike
+        path to the root folder where the inputs will be stored.
+    exp_data_root : PathLike
+        path to the root folder where the experimental data will be stored.
+    access_token : str
+        Authorization token to access the F4E GitLab.
+
+    Returns
+    -------
+    bool
+        True if the inputs were successfully fetched, False otherwise.
+    """
+    extracted_folder = str(
+        fetch_from_gitlab(
+            "https://eng-gitlab.f4e.europa.eu/",
+            "f4e-projects/jade-benchmarks",
+            "main",
+            authorization_token=access_token,
+        )
+    )
+    path_to_inputs = Path(extracted_folder, "inputs")
+    path_to_exp_data = Path(
+        extracted_folder,
+        "exp_results",
+    )
+    success = _install_standard_folder_structure(
+        extracted_folder, inputs_root, exp_data_root, path_to_inputs, path_to_exp_data
+    )
+    return success

--- a/src/jade/config/run_config.py
+++ b/src/jade/config/run_config.py
@@ -140,14 +140,16 @@ class EnvironmentVariables:
     code_configurations : dict[CODE, PathLike] | None
         path to the configuration files for the codes. If None, the default configuration
         will be used which can be found at cfg/exe_config. By default is None.
-    batch_template : PathLike | None
+    batch_template : PathLike | None, optional
         relative path to the batch template for job submission. location is cfg/batch_templates.
         By default is None.
-    batch_system : str | None
+    batch_system : str | None, optional
         name of the batch system to use for job submission. e.g. "slurm". By default is
         None.
-    mpi_prefix : str | None
+    mpi_prefix : str | None, optional
         prefix for the mpi command. e.g. "srun", by default None
+    f4e_gitlab_token : str | None, optional
+        token to access the F4E gitlab. By default is None.
     """
 
     # parallel options
@@ -162,6 +164,7 @@ class EnvironmentVariables:
     batch_template: PathLike | None = None
     batch_system: str | None = None
     mpi_prefix: str | None = None
+    f4e_gitlab_token: str | None = None
 
     def __post_init__(self):
         if self.mpi_tasks is not None:
@@ -181,6 +184,9 @@ class EnvironmentVariables:
                 raise ConfigError(
                     "Batch system is needed for job submission, please provide one"
                 )
+        # make sure that the gitlab token is set to None if empty
+        if self.f4e_gitlab_token == "":
+            self.f4e_gitlab_token = None
 
     @classmethod
     def from_yaml(cls, config_file: PathLike) -> EnvironmentVariables:
@@ -208,6 +214,7 @@ class EnvironmentVariables:
             batch_template=cfg["batch_template"],
             batch_system=cfg["batch_system"],
             mpi_prefix=cfg["mpi_prefix"],
+            f4e_gitlab_token=cfg.get("f4e_gitlab_token", None),
         )
 
 

--- a/src/jade/resources/default_cfg/env_vars_cfg.yml
+++ b/src/jade/resources/default_cfg/env_vars_cfg.yml
@@ -26,3 +26,5 @@ code_configurations: # You can either modify the files at these (relative) paths
 batch_template: batch_template/Slurmtemplate.sh  # batch template. Both relative and absolute paths should work.
 batch_system: sbatch  # the command to submit a job to the cluster (e.g. llsubmit, sbatch, etc.)
 
+# Tokens for closed benchmarks repos
+f4e_gitlab_token:  # token for the F4E gitlab, leave empty if not needed


### PR DESCRIPTION
# Description

This PR allows jade to fetch also inputs from the F4E private GitLab in case an access token is provided in the enviromental variables config file.


Additional dependencies introduced.
- python-gitlab

## Type of change

Please select what type of change this is.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New benchmark
    - [ ] Non-breaking change which entirely uses exisiting classes, structure etc
    - [ ] Breaking change which has implemented new/modified classes etc
- [x] New feature 
    - [x] Non-breaking change which adds functionality
    - [ ] Breaking change fix or feature that would cause existing functionality to not work as expected

## Other changes

- [x] This change requires a documentation update
- [ ] (If Benchmark) This requires additional data that can be obtained from:
    - Benchmark data 1
    - Benchamrk data 2

# Testing

Suitable tests have been added for the CI suite

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] General testing 
    - [x] New and existing unit tests pass locally with my changes
    - [ ] Coverage is >80%