### PR TITLE
avoid translations of dosimetry libs

### DIFF
--- a/docs/source/dev/insertbenchmarks.rst
+++ b/docs/source/dev/insertbenchmarks.rst
@@ -31,6 +31,10 @@ MCNP
 - The input name shall be ``<benchmark_name>.i``
 - weight windows file (if present) should be named ``wwinp``
 
+.. note:: 
+  If the benchmark input uses special dosimetry libraries that should not be translated, their suffix
+  should be added to the ``DOSIMETRY_LIBS`` list in ``jade/helper/constants.py``.
+
 D1SUNED
 -------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "python-docx",
     "aspose-words",
     "requests",
-    "f4enix >= 0.13.0",
+    "f4enix >= 0.14.0",
 #    openmc @ git+https://github.com/openmc-dev/openmc.git@v0.14.0#egg=openmc
     "pyyaml",
     "ttkthemes",

--- a/src/jade/helper/constants.py
+++ b/src/jade/helper/constants.py
@@ -58,3 +58,5 @@ ALLOWED_COLUMN_NAMES = [
     "Cor B",
     "Cor C",
 ]
+
+DOSIMETRY_LIBS = ["34y"]

--- a/src/jade/run/input.py
+++ b/src/jade/run/input.py
@@ -16,7 +16,7 @@ from f4enix.input.MCNPinput import Input as MCNPInput
 from jade.config.run_config import Library, LibraryD1S, LibraryMCNP
 from jade.helper.__openmc__ import OMC_AVAIL
 from jade.helper.aux_functions import PathLike
-from jade.helper.constants import CODE
+from jade.helper.constants import CODE, DOSIMETRY_LIBS
 from jade.helper.errors import ConfigError
 
 if OMC_AVAIL:
@@ -113,7 +113,7 @@ class InputMCNP(Input):
         self.inp = MCNPInput.from_input(filepath)
         self._name = file.split(".")[0]
         self._lib = lib
-        self.lm = LibManager(xsdir_path=lib.path)
+        self.lm = LibManager(xsdir_path=lib.path, dosimetry_lib=DOSIMETRY_LIBS)
 
     @property
     def code(self) -> CODE:
@@ -346,7 +346,7 @@ class InputD1S(Input):
         irrfile = Path(template_folder, f"{self.name}_irrad")
         reacfile = Path(template_folder, f"{self.name}_react")
         self.inp = D1S_Input.from_input(Path(template_folder, file))
-        self.lm = LibManager(xsdir_path=lib.path)
+        self.lm = LibManager(xsdir_path=lib.path, dosimetry_lib=DOSIMETRY_LIBS)
         self._lib = lib
 
         try:


### PR DESCRIPTION
# Description

Include treatment of dosimetry libraries for MCNP. This leverages the latest version of F4Enix that allows to ignore a set of suffix during translation operations.

Fixes #186 

Additional dependencies introduced.
- Bumped minimum version of f4enix >= 0.14.0

## Type of change

Please select what type of change this is.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New benchmark
    - [ ] Non-breaking change which entirely uses exisiting classes, structure etc
    - [ ] Breaking change which has implemented new/modified classes etc
- [ ] New feature 
    - [ ] Non-breaking change which adds functionality
    - [ ] Breaking change fix or feature that would cause existing functionality to not work as expected

## Other changes

- [x] This change requires a documentation update
- [ ] (If Benchmark) This requires additional data that can be obtained from:
    - Benchmark data 1
    - Benchamrk data 2

# Testing

Suitable tests have been added to the CI suite

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] General testing 
    - [x] New and existing unit tests pass locally with my changes
    - [x] Coverage is >80%