### PR TITLE
Change supported python versions and eliminate openmc dependency

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -54,8 +54,19 @@ jobs:
       - name: Install dependencies Linux
         if: runner.os == 'Linux'
         run: |
-          pip install -e .[dev,openmc]
-        
+          pip install -e .[dev]
+      
+      # Cap the openmc installation to 0.15.0 for older python
+      - name: Install openmc (legacy)
+        if: runner.os == 'Linux' || matrix.python-version == '3.10'
+        run: |
+          pip install "openmc @ git+https://github.com/openmc-dev/openmc.git@v0.15.0#egg=openmc
+      
+      - name: Install openmc
+        if: runner.os == 'Linux' || matrix.python-version != '3.10'
+        run: |
+          pip install "openmc @ git+https://github.com/openmc-dev/openmc.git
+
       # Install dependencies windows
       - name: Install dependencies Windows 
         if: runner.os == 'Windows'

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -58,12 +58,12 @@ jobs:
       
       # Cap the openmc installation to 0.15.0 for older python
       - name: Install openmc (legacy)
-        if: runner.os == 'Linux' || matrix.python-version == '3.10'
+        if: runner.os == 'Linux' && matrix.python-version == '3.10'
         run: |
           pip install git+https://github.com/openmc-dev/openmc.git@v0.15.0#egg=openmc
       
       - name: Install openmc
-        if: runner.os == 'Linux' || matrix.python-version != '3.10'
+        if: runner.os == 'Linux' && matrix.python-version != '3.10'
         run: |
           pip install git+https://github.com/openmc-dev/openmc.git
 

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -60,12 +60,12 @@ jobs:
       - name: Install openmc (legacy)
         if: runner.os == 'Linux' || matrix.python-version == '3.10'
         run: |
-          pip install "openmc @ git+https://github.com/openmc-dev/openmc.git@v0.15.0#egg=openmc
+          pip install openmc @ git+https://github.com/openmc-dev/openmc.git@v0.15.0#egg=openmc
       
       - name: Install openmc
         if: runner.os == 'Linux' || matrix.python-version != '3.10'
         run: |
-          pip install "openmc @ git+https://github.com/openmc-dev/openmc.git
+          pip install openmc @ git+https://github.com/openmc-dev/openmc.git
 
       # Install dependencies windows
       - name: Install dependencies Windows 

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, ubuntu-20.04, ubuntu-latest]
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.10", "3.11", '3.12']
         full-test:
           - ${{ contains(github.ref, 'master') || contains(github.ref, 'main') || startsWith(github.ref, 'refs/heads/release') }}
         exclude:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Install openmc
         if: runner.os == 'Linux' || matrix.python-version != '3.10'
         run: |
-          pip install git+https://github.com/openmc-dev/openmc.git"
+          pip install git+https://github.com/openmc-dev/openmc.git
 
       # Install dependencies windows
       - name: Install dependencies Windows 

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -60,12 +60,12 @@ jobs:
       - name: Install openmc (legacy)
         if: runner.os == 'Linux' || matrix.python-version == '3.10'
         run: |
-          pip install openmc @ git+https://github.com/openmc-dev/openmc.git@v0.15.0#egg=openmc
+          pip install git+https://github.com/openmc-dev/openmc.git@v0.15.0#egg=openmc
       
       - name: Install openmc
         if: runner.os == 'Linux' || matrix.python-version != '3.10'
         run: |
-          pip install openmc @ git+https://github.com/openmc-dev/openmc.git
+          pip install git+https://github.com/openmc-dev/openmc.git"
 
       # Install dependencies windows
       - name: Install dependencies Windows 

--- a/docs/source/usage/installation.rst
+++ b/docs/source/usage/installation.rst
@@ -23,8 +23,8 @@ Or if you are using Anaconda:
   | ``conda activate jade``
 
 .. warning:: 
-  JADE officially supports only Python 3.9, 3.10 and 3.11. There are known
-  compatibility issues if Python 3.12 or later is used.
+  JADE officially supports only Python 3.10, 3.11 and 3.12.
+  It may work with other versions, but they are untested.
 
 Install the JADE package
 ------------------------
@@ -36,20 +36,14 @@ Jade is hosted on PyPi under the name of ``jadevv``. To install it, run:
 
   | ``pip install jadevv``
 
-If the user wishes to use the OpenMC features within JADE, they can install the
-additional dependency by running:
-
-  | ``pip install jadevv[openmc]``
-
-or 
-
-  | ``pip install "jadevv[openmc]"``
-
-Alternatively, the user can install OpenMC separately in the same python environment.
+It is responsability of the user to install OpenMC in the same python environment 
+in case they are planning to use it. This guarantees better visibility for the users
+on which version of OpenMC is being run.
 
 .. warning:: 
-  Note that currently OpenMC is supported only up to version 0.14.0 and that the user
-  will need to have git installed on their system if using the ``[openmc]`` option. 
+  Development cycles of OpenMC are quite fast. For instance, after version 0.15.0
+  OpenMC does not support anymore python 3.11. Be sure to install an OpenMC version
+  that your python environment supports.  
 
 .. _installdevelop:
 

--- a/docs/source/usage/installation.rst
+++ b/docs/source/usage/installation.rst
@@ -36,13 +36,13 @@ Jade is hosted on PyPi under the name of ``jadevv``. To install it, run:
 
   | ``pip install jadevv``
 
-It is responsability of the user to install OpenMC in the same python environment 
+It is responsibility of the user to install OpenMC in the same python environment 
 in case they are planning to use it. This guarantees better visibility for the users
 on which version of OpenMC is being run.
 
 .. warning:: 
   Development cycles of OpenMC are quite fast. For instance, after version 0.15.0
-  OpenMC does not support anymore python 3.11. Be sure to install an OpenMC version
+  OpenMC does not support anymore python 3.10. Be sure to install an OpenMC version
   that your python environment supports.  
 
 .. _installdevelop:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,10 +41,9 @@ dev = [
     "ruff"  # best formatter that should be used by everybody
     ]
 openmc = [
-    "openmc @ git+https://github.com/openmc-dev/openmc.git; python_version >= '3.11'",
-    "openmc @ git+https://github.com/openmc-dev/openmc.git@v0.15.0#egg=openmc; python_version < '3.11'"
-
-    ]
+    "openmc @ git+https://github.com/openmc-dev/openmc.git",  # Default for all Python versions
+    "openmc @ git+https://github.com/openmc-dev/openmc.git@v0.15.0#egg=openmc; python_version < '3.11'"  # Specific version for Python < 3.11
+]
 
 [project.urls]
 Homepage = "https://github.com/JADE-V-V/JADE"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,9 @@ dev = [
     "ruff"  # best formatter that should be used by everybody
     ]
 openmc = [
-    "openmc @ git+https://github.com/openmc-dev/openmc.git"
+    "openmc @ git+https://github.com/openmc-dev/openmc.git; python_version >= '3.11'",
+    "openmc @ git+https://github.com/openmc-dev/openmc.git@v0.15.0#egg=openmc; python_version < '3.11'"
+
     ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,10 +40,6 @@ dev = [
     "pytest-xvfb",  # needed for headless display
     "ruff"  # best formatter that should be used by everybody
     ]
-openmc = [
-    "openmc @ git+https://github.com/openmc-dev/openmc.git",  # Default for all Python versions
-    "openmc @ git+https://github.com/openmc-dev/openmc.git@v0.15.0#egg=openmc; python_version < '3.11'"  # Specific version for Python < 3.11
-]
 
 [project.urls]
 Homepage = "https://github.com/JADE-V-V/JADE"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
 ]
 description = "JADE, a V&V tool for nuclear data libraries and transport codes"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: European Union Public Licence 1.2 (EUPL 1.2)",
@@ -24,14 +24,11 @@ dependencies = [
     "xlsxwriter",
     "openpyxl",
     "matplotlib",
-    # Latest version of scipy that supports Python 3.9.
-    # This is a temporary fix and should be removed once Python 3.9 support is dropped in JADE. 
-    "scipy == 1.13.1",
+    "scipy",
     "python-docx",
     "aspose-words",
     "requests",
     "f4enix >= 0.14.0",
-#    openmc @ git+https://github.com/openmc-dev/openmc.git@v0.14.0#egg=openmc
     "pyyaml",
     "ttkthemes",
     "seaborn"
@@ -44,7 +41,7 @@ dev = [
     "ruff"  # best formatter that should be used by everybody
     ]
 openmc = [
-    "openmc @ git+https://github.com/openmc-dev/openmc.git@v0.14.0#egg=openmc"
+    "openmc @ git+https://github.com/openmc-dev/openmc.git"
     ]
 
 [project.urls]


### PR DESCRIPTION
# Description

OpenMC development cycle is quite fast and the range of python versions supported is not very broad. For this reason, the ``openmc`` dependency is removed. At the same time, JADE python support is extended to v3.12 and removed for v3.9.
This also guarantees more awareness for users about which openmc version they are using.

Installation of OpenMC is still performed in CI for testing purposes.

Installation documentation has been updated accordingly.


Additional dependencies introduced.
- ``openmc`` is removed

## Type of change

Please select what type of change this is.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New benchmark
    - [ ] Non-breaking change which entirely uses exisiting classes, structure etc
    - [ ] Breaking change which has implemented new/modified classes etc
- [x] New feature 
    - [ ] Non-breaking change which adds functionality
    - [ ] Breaking change fix or feature that would cause existing functionality to not work as expected

## Other changes

- [x] This change requires a documentation update
- [ ] (If Benchmark) This requires additional data that can be obtained from:
    - Benchmark data 1
    - Benchamrk data 2

# Testing

Test is performed in CI

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] General testing 
    - [x] New and existing unit tests pass locally with my changes
    - [x] Coverage is >80%