### PR TITLE
Hot fix Sphere Leakage OpenMC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ docs/source/_static/
 docs/source/_templates/
 JADE.egg-info/
 jade.egg-info/
+jadevv.egg-info/
 build/
 .DS_Store/
 

--- a/src/jade/run/benchmark.py
+++ b/src/jade/run/benchmark.py
@@ -526,7 +526,8 @@ class SphereBenchmarkRun(BenchmarkRun):
                 inp = InputMCNPSphere(template_folder, lib, zaid, str(-1 * density))
                 single_run = SingleRunMCNP(inp, lib, nps)
             else:
-                raise NotImplementedError(f"Code {code} not supported for Sphere")
+                inp = InputOpenMcSphere(template_folder, lib, zaid, str(-1 * density))
+                single_run = SingleRunOpenMC(inp, lib, nps)
             self._run_single_run(
                 sub_bench_folder, self.benchmark_templates_root, single_run
             )

--- a/src/jade/run/benchmark.py
+++ b/src/jade/run/benchmark.py
@@ -525,9 +525,11 @@ class SphereBenchmarkRun(BenchmarkRun):
                     )
                 inp = InputMCNPSphere(template_folder, lib, zaid, str(-1 * density))
                 single_run = SingleRunMCNP(inp, lib, nps)
-            else:
+            elif code == CODE.OPENMC:
                 inp = InputOpenMcSphere(template_folder, lib, zaid, str(-1 * density))
                 single_run = SingleRunOpenMC(inp, lib, nps)
+            else:
+                raise NotImplementedError(f"Code {code} not supported for Sphere")
             self._run_single_run(
                 sub_bench_folder, self.benchmark_templates_root, single_run
             )
@@ -551,7 +553,9 @@ class SphereBenchmarkRun(BenchmarkRun):
                 )
                 single_run = SingleRunMCNP(inp, lib, int(self.config.nps))
             elif code == CODE.OPENMC:
-                inp = InputOpenMcSphere(template_folder, lib)
+                inp = InputOpenMcSphere(
+                    template_folder, lib, material, str(-1 * float(density))
+                )
                 single_run = SingleRunOpenMC(inp, lib, int(self.config.nps))
             else:
                 raise NotImplementedError(f"Code {code} not supported for Sphere")

--- a/src/jade/run/input.py
+++ b/src/jade/run/input.py
@@ -273,7 +273,7 @@ class InputOpenMcSphere(InputOpenMC):
 
     def _assign_zaid_material(self, zaid: str | Material, density: str):
         material = self._get_material(zaid)
-        material.density = -float(density)
+        material.density = float(density)
         materials = MatCardsList([material])
         # Assign material
         self.inp.matlist_to_openmc(materials, self.lm)

--- a/tests/run/test_benchmark.py
+++ b/tests/run/test_benchmark.py
@@ -103,6 +103,35 @@ class TestSphereBenchmarkRun:
             len(os.listdir(Path(tmpdir, "_mcnp_-_FENDL 3.2c_/Sphere/Sphere_1001_H-1")))
             == 2
         )
+    
+    @pytest.mark.skipif(not OMC_AVAIL, reason="OpenMC not available")
+    def test_run_openmc(self, tmpdir):
+        with as_file(RUN_RES.joinpath('cross_sections.xml')) as infile:
+            lib = LibraryOpenMC(name="ENDF VII-1", path=infile)
+        perform = [
+            (CODE.OPENMC, lib),
+        ]
+        cfg = BenchmarkRunConfig(
+            description="Sphere benchmark",
+            name="Sphere",
+            run=perform,
+            nps=10,
+            only_input=True,
+            custom_inp=2,
+            additional_settings_path=DEFAULT_CFG.joinpath("benchmarks/Sphere"),
+        )
+
+        env_vars = EnvironmentVariables(
+            None,
+            0,
+            {CODE.OPENMC: "openmc"},
+            run_mode=RunMode.SERIAL,
+        )
+
+        benchmark = SphereBenchmarkRun(cfg, tmpdir, BENCHMARKS_ROOT, env_vars)
+        benchmark.run()
+
+        assert len(os.listdir(tmpdir)) == 1
 
 
 class TestSphereSDDRBenchmarkRun:

--- a/tests/run/test_input.py
+++ b/tests/run/test_input.py
@@ -5,12 +5,17 @@ from importlib.resources import as_file, files
 from pathlib import Path
 
 import f4enix.input.MCNPinput as ipt
+from f4enix.input.libmanager import LibManager
+from f4enix.input.materials import Zaid
 import pytest
 
 import jade.resources.default_cfg.benchmarks as bench
 import tests.dummy_structure.benchmark_templates as res
 from jade.config.run_config import LibraryD1S, LibraryMCNP, LibraryOpenMC
 from jade.helper.__openmc__ import OMC_AVAIL
+if OMC_AVAIL:
+    import openmc
+    from jade.helper.openmc import OpenMCInputFiles
 from jade.run.input import (
     InputD1SSphere,
     InputMCNP,
@@ -70,8 +75,16 @@ class TestIputMCNP:
 
 @pytest.mark.skipif(not OMC_AVAIL, reason="OpenMC not available")
 class TestIputOpenMC:
-    # TODO
-    pass
+    def test_zaid_openmc(self):
+        nuclide = Zaid.from_string('1000.31c -1')
+        material = openmc.Material()
+        lm = LibManager()
+        OpenMCInputFiles.zaid_to_openmc(nuclide, material, lm)
+        assert material.nuclides[0].name == 'H0'
+
+        nuclide = Zaid.from_string('1001.31c -1')
+        OpenMCInputFiles.zaid_to_openmc(nuclide, material, lm)
+        assert material.nuclides[1].name == 'H1'
 
 
 class TestInputMCNPSphere:
@@ -94,7 +107,7 @@ class TestInputMCNPSphere:
 class TestInputOpenMCSphere:
     def test_input_generation(self, tmpdir, libOpenMC):
         template_folder = TEMPLATE_ROOT.joinpath("Sphere/Sphere/openmc")
-        inp = InputOpenMcSphere(template_folder, libOpenMC, "1001", "1.0")
+        inp = InputOpenMcSphere(template_folder, libOpenMC, "1001", "-1.0")
         inp.set_nps(10)
         inp.translate()
         inp.write(tmpdir)


### PR DESCRIPTION
# Description

The Sphere leakage benchmark was broken for OpenMC, this PR fixes it:

- Removed the NotImplementedError
- Fixed the natural zaid call in the zaid conversion
- Added tests

## Type of change

Please select what type of change this is.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New benchmark
    - [ ] Non-breaking change which entirely uses existing classes, structure etc
    - [ ] Breaking change which has implemented new/modified classes etc
- [ ] New feature 
    - [ ] Non-breaking change which adds functionality
    - [ ] Breaking change fix or feature that would cause existing functionality to not work as expected

## Other changes

- [ ] This change requires a documentation update
- [ ] (If Benchmark) This requires additional data that can be obtained from:
    - Benchmark data 1
    - Benchmark data 2

# Testing

Suitable tests have been added to the CI, manual testing has also been performed.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] General testing 
    - [x] New and existing unit tests pass locally with my changes
    - [x] Coverage is >80%