### PR TITLE
Correct cross_sections.xml parsing and add material names to the sphere leakage benchmark

### DIFF
--- a/src/jade/config/run_config.py
+++ b/src/jade/config/run_config.py
@@ -251,15 +251,18 @@ class LibraryOpenMC(Library):
     """
 
     def __post_init__(self):
-        # in OpenMC the path points to a folder where a number of hdf files are stored.
-        # I am assuming here that the format is always something like Cd116.h5
-        # If this is not the case, we will be forced in the future to parse each single
-        # table to get the correct zaid name. This could be expensive.
+        # Assumptions:
+        # material is alwasy of the type "Ti50" or "Ti50_m1" if metastable
+        # look only for type=neutron
         lm = LibManager(defaultlib="00c")  # Just for name conversions
         self._available_zaids = []
         root = ET.parse(self.path).getroot()
         for type_tag in root.findall("library"):
             zaidname = type_tag.get("materials")
+            zaid_type = type_tag.get("type")
+            # Check only neutrons and remove metastable
+            if zaid_type != "neutron" or "_" in str(zaidname):
+                continue
             try:
                 zaidnum = lm.get_zaidnum(str(zaidname))
             except ValueError:

--- a/src/jade/resources/default_cfg/benchmarks/Sphere/MaterialsSettings.csv
+++ b/src/jade/resources/default_cfg/benchmarks/Sphere/MaterialsSettings.csv
@@ -1,22 +1,22 @@
 NPS cut-off,CTME cut-off,Relative Error cut-off,Density [g/cc],Name,Symbol,Let Override
 ,,F32-0.0005,7.93,SS316L(N)-IG,M101,True
 ,,F32-0.0005,0.946,Water,M400,True
-,,F32-0.0005,2.3,Boron Carbide,M203,True
-,,F32-0.0005,2.2875,Ordinary Concrete,M200,True
-,,F32-0.0005,2.33,Natural Silicon,M900,True
-,,F32-0.0005,0.93,Polyethylene (non-borated),M901,True
+,,F32-0.0005,2.3,Boron-Carbide,M203,True
+,,F32-0.0005,2.2875,Ordinary-Concrete,M200,True
+,,F32-0.0005,2.33,Natural-Silicon,M900,True
+,,F32-0.0005,0.93,Polyethylene-(non-borated),M901,True
 ,,F32-0.0005,19,Tungsten,M74,True
 ,,F32-0.0005,3.18,CaF2,M10,True
-,,F32-0.0005,10.49,Pure Silver,M11,True
-,,F32-0.0005,11.348,Pure Lead,M9011,True
+,,F32-0.0005,10.49,Pure-Silver,M11,True
+,,F32-0.0005,11.348,Pure-Lead,M9011,True
 ,,F32-0.0005,2.7,Al-6061,M200133,True
 ,,F32-0.0005,7.6,Al-Bronze,M200117,True
-,,F32-0.0005,3.6,Borated Heavy Concrete,M200368,True
-,,F32-0.0005,8.9,Copper Chromium Zirconium,M302,True
+,,F32-0.0005,3.6,Borated-Heavy-Concrete,M200368,True
+,,F32-0.0005,8.9,Copper-Chromium-Zirconium,M302,True
 ,,F32-0.0005,7.8,Eurofer-97,M9001,True
 ,,F32-0.0005,8.2,Inconel-718,M9010,True
 ,,F32-0.0005,6.03,NbTi,M909,True
 ,,F32-0.0005,1.82,Beryllium,M4,True
-,,F32-0.0005,4.43,Titanium alloy Grade 5,M910,True
+,,F32-0.0005,4.43,Titanium-alloy-Grade-5,M910,True
 ,,F32-0.0005,7.92,SS660,M125,True
 ,,F32-0.0005,0.4,Microtherm,M911,True

--- a/src/jade/resources/default_cfg/benchmarks/SphereSDDR/MaterialsSettings.csv
+++ b/src/jade/resources/default_cfg/benchmarks/SphereSDDR/MaterialsSettings.csv
@@ -1,22 +1,22 @@
 NPS cut-off,CTME cut-off,Relative Error cut-off,Density [g/cc],Name,Symbol,Let Override
 ,,F32-0.0005,7.93,SS316L(N)-IG,M101,True
 ,,F32-0.0005,0.946,Water,M400,True
-,,F32-0.0005,2.3,Boron Carbide,M203,True
-,,F32-0.0005,2.2875,Ordinary Concrete,M200,True
-,,F32-0.0005,2.33,Natural Silicon,M900,True
-,,F32-0.0005,0.93,Polyethylene (non-borated),M901,True
+,,F32-0.0005,2.3,Boron-Carbide,M203,True
+,,F32-0.0005,2.2875,Ordinary-Concrete,M200,True
+,,F32-0.0005,2.33,Natural-Silicon,M900,True
+,,F32-0.0005,0.93,Polyethylene-(non-borated),M901,True
 ,,F32-0.0005,19,Tungsten,M74,True
 ,,F32-0.0005,3.18,CaF2,M10,True
-,,F32-0.0005,10.49,Pure Silver,M11,True
-,,F32-0.0005,11.348,Pure Lead,M9011,True
+,,F32-0.0005,10.49,Pure-Silver,M11,True
+,,F32-0.0005,11.348,Pure-Lead,M9011,True
 ,,F32-0.0005,2.7,Al-6061,M200133,True
 ,,F32-0.0005,7.6,Al-Bronze,M200117,True
-,,F32-0.0005,3.6,Borated Heavy Concrete,M200368,True
-,,F32-0.0005,8.9,Copper Chromium Zirconium,M302,True
+,,F32-0.0005,3.6,Borated-Heavy Concrete,M200368,True
+,,F32-0.0005,8.9,Copper-Chromium Zirconium,M302,True
 ,,F32-0.0005,7.8,Eurofer-97,M9001,True
 ,,F32-0.0005,8.2,Inconel-718,M9010,True
 ,,F32-0.0005,6.03,NbTi,M909,True
 ,,F32-0.0005,1.82,Beryllium,M4,True
-,,F32-0.0005,4.43,Titanium alloy Grade 5,M910,True
+,,F32-0.0005,4.43,Titanium-alloy-Grade 5,M910,True
 ,,F32-0.0005,7.92,SS660,M125,True
 ,,F32-0.0005,0.4,Microtherm,M911,True

--- a/src/jade/run/benchmark.py
+++ b/src/jade/run/benchmark.py
@@ -537,9 +537,12 @@ class SphereBenchmarkRun(BenchmarkRun):
         for material in tqdm(materials.materials[:limit], desc="Materials"):
             # Get density
             density = settings_mat.loc[material.name.upper(), "Density [g/cc]"]
+            extended_name = settings_mat.loc[material.name.upper(), "Name"]
 
             # derive the sub-benchmark folder name
-            sub_bench_folder_name = f"{self.config.name}_{material.name}"
+            sub_bench_folder_name = (
+                f"{self.config.name}_{material.name}_{extended_name}"
+            )
             sub_bench_folder = Path(root_benchmark, sub_bench_folder_name)
             os.mkdir(sub_bench_folder)
 

--- a/tests/config/test_run_config.py
+++ b/tests/config/test_run_config.py
@@ -125,5 +125,6 @@ class TestLibraryOpenMC:
         with as_file(CONF_RES.joinpath("cross_sections.xml")) as file:
             lib = LibraryOpenMC("dummy", file)
 
-        assert "1001" in lib.get_lib_zaids()
-        assert "1000" in lib.get_lib_zaids()
+        zaids = lib.get_lib_zaids()
+        assert "1001" in zaids
+        assert len(zaids) == len(set(zaids))  # no duplicates


### PR DESCRIPTION
# Description

This hot fix solves 2 issues encountered when experimenting with the Sphere leakage benchmark and OpenMC:

- the cross_sections.xml parser was duplicating isotopes due to incorrect interpretation of metastable zaids leading to an error during the generation of the sphere inputs
- the material names were missing in the sphere benchmark (only material ID was present)


## Type of change

Please select what type of change this is.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New benchmark
    - [ ] Non-breaking change which entirely uses existing classes, structure etc
    - [ ] Breaking change which has implemented new/modified classes etc
- [ ] New feature 
    - [ ] Non-breaking change which adds functionality
    - [ ] Breaking change fix or feature that would cause existing functionality to not work as expected

## Other changes

- [ ] This change requires a documentation update
- [ ] (If Benchmark) This requires additional data that can be obtained from:
    - Benchmark data 1
    - Benchmark data 2

# Testing

Added a test to ensure cross_sections.xml is now parsed correctly. Manual test with generation of all isotopes and material has also been conducted with OpenMC and JEFF 3.3

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] General testing 
    - [x] New and existing unit tests pass locally with my changes
    - [x] Coverage is >80%