### PR TITLE
selective config operators

### DIFF
--- a/docs/source/dev/insertbenchmarks.rst
+++ b/docs/source/dev/insertbenchmarks.rst
@@ -236,6 +236,25 @@ An example of a *result* configuration is shown below:
   The *results* do not have to be present in all benchmark cases/runs. When they are not
   found, they are simply skipped.
 
+In some cases it may be useful to produce certain results only from some cases/runs and
+not from others. Or maybe different modifiers need to be applied in different runs.
+An example may be the case of having a benchmark composed by two runs with the same tallies.
+Nevertheless, in one run the geometry is slightly different from the other or the irradiation
+scenario is different and a distinction is needed in the applied modifiers. In this case,
+an optional parameter can be specified in the *result* config to specify a list of runs/cases
+to which the configuration is applicable:
+
+.. code-block:: yaml
+
+  # Result configuration. the result name can contain spaces.
+  result name specific for a run1:
+    apply_to: [run1] # A list of runs/cases to which the configuration is applicable.
+    concat_option: sum  # The concatenation option 'sum' is used.
+    44: [[no_action, {}]]  # Example of tally that is left untouched. 44 is the tally identifier used in the transport code.
+    46: [[scale, {"factor": 1e5}], [lethargy, {}]]  # Example of tally that is scaled and converted to flux per unit lethargy.
+
+
+
 Add the excel config file
 =========================
 

--- a/src/jade/config/raw_config.py
+++ b/src/jade/config/raw_config.py
@@ -49,11 +49,15 @@ class ResultConfig:
         function should also be provided.
     concat_option : TallyConcatOption
         How to combine the tallies
+    apply_to: list[str] | None
+        if None, the result config applies to run. If not, it applies only to
+        the specified runs in the list.
     """
 
     name: int
     modify: dict[int, list[tuple[TallyModOption, dict]]]
     concat_option: TallyConcatOption
+    apply_to: list[str] | None = None
 
     @classmethod
     def from_dict(cls, dictionary: dict, name) -> ResultConfig:
@@ -70,6 +74,7 @@ class ResultConfig:
             name=name,
             modify=mods,
             concat_option=concat_option,
+            apply_to=dictionary.get("apply_to", None),
         )
 
 

--- a/src/jade/post/raw_processor.py
+++ b/src/jade/post/raw_processor.py
@@ -33,10 +33,16 @@ class RawProcessor:
         NotImplementedError
             If the code is not implemented yet for raw data processing.
         """
-        self.cfg = cfg
         self.sim_folder = sim_folder
         self.out_folder = out_folder
         self.single_run_name = os.path.basename(sim_folder)
+
+        # Retain only the applicable result config
+        applicable_results = []
+        for result in cfg.results:
+            if result.apply_to is None or self.single_run_name in result.apply_to:
+                applicable_results.append(result)
+        self.cfg = ConfigRawProcessor(applicable_results)
 
         # adjourn the metadata
         self.metadata = self._read_metadata_run()

--- a/tests/post/test_raw_processor.py
+++ b/tests/post/test_raw_processor.py
@@ -57,6 +57,18 @@ class TestRawProcessor:
         df2 = pd.read_csv(res2path)
         assert df2.iloc[0]["Value"] == pytest.approx(2 * 10 * 1.12099e-01, 1e-3)
         assert len(df1) == 191
+        os.remove(res1path)
+        os.remove(res2path)
+
+        # test the apply_to option
+        cfg.results[0].apply_to = ["Oktavian_Al"]
+        cfg.results[1].apply_to = ["Dummy"]
+        processor = RawProcessor(cfg, folder, tmpdir)
+        processor.process_raw_data()
+        res1path = Path(tmpdir, f"{processor.single_run_name} 1.csv")
+        assert os.path.exists(res1path)
+        res2path = Path(tmpdir, f"{processor.single_run_name} 2.csv")
+        assert not os.path.exists(res2path)
 
     def test_Sphere_mcnp(self, tmpdir):
         with as_file(RAW_CFG_FILES_MCNP.joinpath("Sphere.yaml")) as f:


### PR DESCRIPTION
# Description

In some cases it may be useful to produce certain results only from some cases/runs and not from others. Or maybe different modifiers need to be applied in different runs. An example may be the case of having a benchmark composed by two runs with the same tallies. Nevertheless, in one run the geometry is slightly different from the other or the irradiation scenario is different and a distinction is needed in the applied modifiers. In this case, an optional parameter can be specified in the *result* config to specify a list of runs/cases to which the configuration is applicable.

## Type of change

Please select what type of change this is.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New benchmark
    - [ ] Non-breaking change which entirely uses existing classes, structure etc
    - [ ] Breaking change which has implemented new/modified classes etc
- [x] New feature 
    - [x] Non-breaking change which adds functionality
    - [ ] Breaking change fix or feature that would cause existing functionality to not work as expected

## Other changes

- [x] This change requires a documentation update
- [ ] (If Benchmark) This requires additional data that can be obtained from:
    - Benchmark data 1
    - Benchmark data 2

# Testing

Suitable tests have been added to the CI pipeline

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] General testing 
    - [x] New and existing unit tests pass locally with my changes
    - [x] Coverage is >80%