### PR TITLE
Addition of the cumulative sum tally modifier

### DIFF
--- a/docs/source/dev/insertbenchmarks.rst
+++ b/docs/source/dev/insertbenchmarks.rst
@@ -207,9 +207,9 @@ The currently supported modifiers are:
 * ``delete_cols``: deletes columns from the tally. The keyarg to provide is *cols* which expects a list
   of column names to be deleted.
 
-* ``format_decimals``: formats the decimals of the data contained in specific columns. A 'decimals' dictionary is expected as a 
-  keyarg, where the keys should be the column names to be formatted and the values should be the corresponding number of decimals 
-  to keep. 
+* ``format_decimals``: formats the decimals of the data contained in specific columns. A *decimals* dictionary is expected as a
+  keyarg, where the keys should be the column names to be formatted and the values should be the corresponding number of decimals
+  to keep.
 
 * ``tof_to_energy``: converts the time-of-flight to energy. The tally is expected
   to be binned in time and a new column *Energy* will be created. 
@@ -230,6 +230,9 @@ The currently supported modifiers are:
 
   * *column*: the name of the column to be used for the subset selection.
   * *values*: list of values in *column* identifying the rows to be retained.
+
+* ``cumulative_sum``: computes the cumulative sum of a specific column. The optional keyarg to provide is *column*, the name of the column 
+  to be used for the cumulative sum. If no *column* argument is provided, the cumulative sum is computed on the 'Value' column by default.
 
 More than one modifiers can be applied in series to a single tally.
 If your benchmark requires a new modifier, please refer to :ref:`add_tally_mod`.

--- a/src/jade/config/raw_config.py
+++ b/src/jade/config/raw_config.py
@@ -97,6 +97,7 @@ class TallyModOption(Enum):
     FORMAT_DECIMALS = "format_decimals"
     TOF_TO_ENERGY = "tof_to_energy"
     SELECT_SUBSET = "select_subset"
+    CUMULATIVE_SUM = "cumulative_sum"
 
 
 class TallyConcatOption(Enum):

--- a/src/jade/post/manipulate_tally.py
+++ b/src/jade/post/manipulate_tally.py
@@ -218,6 +218,20 @@ def tof_to_energy(
     return tally
 
 
+def cumulative_sum(tally: pd.DataFrame, column: str = "Value") -> pd.DataFrame:
+    """Compute the cumulative sum of the specified column.
+
+    Parameters
+    ----------
+    tally : pd.DataFrame
+        tally dataframe to modify
+    column: str
+        name of the column to compute the cumulative sum for. Default is "Value".
+    """
+    tally[column] = tally[column].cumsum()
+    return tally
+
+
 MOD_FUNCTIONS = {
     TallyModOption.LETHARGY: by_lethargy,
     TallyModOption.SCALE: scale,
@@ -234,6 +248,7 @@ MOD_FUNCTIONS = {
     TallyModOption.FORMAT_DECIMALS: format_decimals,
     TallyModOption.TOF_TO_ENERGY: tof_to_energy,
     TallyModOption.SELECT_SUBSET: select_subset,
+    TallyModOption.CUMULATIVE_SUM: cumulative_sum,
 }
 
 

--- a/tests/post/test_manipulate_tally.py
+++ b/tests/post/test_manipulate_tally.py
@@ -13,6 +13,7 @@ from src.jade.post.manipulate_tally import (
     by_lethargy,
     concat_tallies,
     condense_groups,
+    cumulative_sum,
     delete_cols,
     divide_by_bin,
     format_decimals,
@@ -273,3 +274,21 @@ def test_select_subset():
     result = select_subset(df.copy(), "Energy", [1, 3])
 
     assert len(result) == 2
+
+
+def test_cumulative_sum():
+    data = {
+        "Time": [1, 2, 3, 4],
+        "Value": [10, 20, 30, 40],
+    }
+    df = pd.DataFrame(data)
+
+    result = cumulative_sum(df.copy())
+    expected_values = [10, 30, 60, 100]
+    assert result["Time"].tolist() == data["Time"]
+    assert result["Value"].tolist() == expected_values
+
+    result = cumulative_sum(df.copy(), column="Time")
+    expected_values = [1, 3, 6, 10]
+    assert result["Time"].tolist() == expected_values
+    assert result["Value"].tolist() == data["Value"]


### PR DESCRIPTION
# Description

This pull request includes the addition of the tally modifier _cumulative_sum_. As a part of this addition:
- The _cumulative_sum_ function includes the option to pass the name of the column to be used for the cumulative sum, but default if 'Value'.
- The test _test_cumulative_sum_ was implemented in _test_manipulate_tally.py_. The function is tested both by using the default 'Value' column and a "custom" column name.
- The tally modifier's name and description was added to JADE's documentation.

No additional dependencies were introduced.

## Type of change

Please select what type of change this is.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New benchmark
    - [ ] Non-breaking change which entirely uses existing classes, structure etc
    - [ ] Breaking change which has implemented new/modified classes etc
- [x] New feature 
    - [x] Non-breaking change which adds functionality
    - [ ] Breaking change fix or feature that would cause existing functionality to not work as expected

## Other changes

- [x] This change requires a documentation update
- [ ] (If Benchmark) This requires additional data that can be obtained from:
    - Benchmark data 1
    - Benchmark data 2

# Testing

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Run all the test functions currently available in the tests folder.
- Added _test_cumulative_sum_ in _test_manipulate_tally.py_ to check the correct operation of the newly added tally modifier.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] General testing 
    - [x] New and existing unit tests pass locally with my changes
    - [x] Coverage is >80%