### PR TITLE
Correction of the error propagation in tally modifiers + addition of TENDL 2017 as a dosimetry library

### DIFF
--- a/src/jade/helper/constants.py
+++ b/src/jade/helper/constants.py
@@ -59,4 +59,4 @@ ALLOWED_COLUMN_NAMES = [
     "Cor C",
 ]
 
-DOSIMETRY_LIBS = ["34y"]
+DOSIMETRY_LIBS = ["34y", "17c"]

--- a/src/jade/post/manipulate_tally.py
+++ b/src/jade/post/manipulate_tally.py
@@ -151,9 +151,10 @@ def groupby(tally: pd.DataFrame, by: str, action: str) -> pd.DataFrame:
         grouped = tally
         # Error propagation considering that tally["Error"] are relative errors
         # Valid both for sum and mean
-        error = (
+        error = pd.Series(
             np.sqrt(((tally["Error"] * tally["Value"]) ** 2).sum())
-            / tally["Value"].sum()
+            / tally["Value"].sum(),
+            name="Error",
         )
     else:
         value_df = tally.set_index(by)["Value"]
@@ -174,11 +175,11 @@ def groupby(tally: pd.DataFrame, by: str, action: str) -> pd.DataFrame:
     if action == "sum":
         df = grouped.sum()
         # Application of the computed error propagation
-        df["Error"] = error
+        df["Error"] = error.values
     elif action == "mean":
         df = grouped.mean()
         # Application of the computed error propagation
-        df["Error"] = error
+        df["Error"] = error.values
     elif action == "max":
         # No error propagation needed when taking the max
         df = grouped.max()

--- a/src/jade/post/manipulate_tally.py
+++ b/src/jade/post/manipulate_tally.py
@@ -149,6 +149,8 @@ def groupby(tally: pd.DataFrame, by: str, action: str) -> pd.DataFrame:
 
     if by == "all":
         grouped = tally
+        # Error propagation considering that tally["Error"] are relative errors
+        # Valid both for sum and mean
         error = (
             np.sqrt(((tally["Error"] * tally["Value"]) ** 2).sum())
             / tally["Value"].sum()
@@ -160,6 +162,8 @@ def groupby(tally: pd.DataFrame, by: str, action: str) -> pd.DataFrame:
         for idx_val in error_df.index.unique():
             subset_error = error_df.loc[idx_val]
             subset_value = value_df.loc[idx_val]
+            # Error propagation considering that tally["Error"] are relative errors
+            # Valid both for sum and mean
             err = (
                 np.sqrt(np.sum((subset_error * subset_value) ** 2)) / subset_value.sum()
             )
@@ -169,13 +173,17 @@ def groupby(tally: pd.DataFrame, by: str, action: str) -> pd.DataFrame:
 
     if action == "sum":
         df = grouped.sum()
+        # Application of the computed error propagation
         df["Error"] = error
     elif action == "mean":
         df = grouped.mean()
+        # Application of the computed error propagation
         df["Error"] = error
     elif action == "max":
+        # No error propagation needed when taking the max
         df = grouped.max()
     elif action == "min":
+        # No error propagation needed when taking the min
         df = grouped.min()
 
     if isinstance(df, pd.Series):
@@ -242,6 +250,7 @@ def cumulative_sum(tally: pd.DataFrame, column: str = "Value") -> pd.DataFrame:
     original_tally = tally.copy()
     tally[column] = tally[column].cumsum()
     if column == "Value":
+        # Error propagation considering that tally["Error"] are relative errors
         tally["Error"] = (
             np.sqrt(((tally["Error"] * original_tally[column]) ** 2).cumsum())
             / tally[column]

--- a/tests/post/test_manipulate_tally.py
+++ b/tests/post/test_manipulate_tally.py
@@ -206,7 +206,10 @@ def test_groupby():
     df = pd.DataFrame(data)
     result = groupby(df.copy(), "Energy", "sum")
     assert (result["Value"] == [3, 7]).all()
-    assert result["Error"].iloc[0] == math.sqrt(0.1**2 + 0.2**2)
+    assert (
+        result["Error"].iloc[0]
+        == np.sqrt((0.1 * 1) ** 2 + (0.2 * 2) ** 2) / result["Value"].iloc[0]
+    )
     result = groupby(df.copy(), "Energy", "mean")
     assert (result["Value"] == [1.5, 3.5]).all()
     result = groupby(df.copy(), "Energy", "max")
@@ -216,7 +219,11 @@ def test_groupby():
 
     result = groupby(df.copy(), "all", "sum")
     assert result["Value"].iloc[0] == 10
-    assert result["Error"].iloc[0] == math.sqrt(0.1**2 + 0.2**2 + 0.1**2 + 0.1**2)
+    assert (
+        result["Error"].iloc[0]
+        == math.sqrt((0.1 * 1) ** 2 + (0.2 * 2) ** 2 + (0.1 * 3) ** 2 + (0.1 * 4) ** 2)
+        / result["Value"].iloc[0]
+    )
     assert len(result) == 1
 
 

--- a/tests/post/test_manipulate_tally.py
+++ b/tests/post/test_manipulate_tally.py
@@ -280,15 +280,25 @@ def test_cumulative_sum():
     data = {
         "Time": [1, 2, 3, 4],
         "Value": [10, 20, 30, 40],
+        "Error": [0.1, 0.2, 0.3, 0.4],
     }
     df = pd.DataFrame(data)
 
     result = cumulative_sum(df.copy())
     expected_values = [10, 30, 60, 100]
+    expected_error = [
+        0.1,
+        np.sqrt((0.1 * 10) ** 2 + (0.2 * 20) ** 2) / 30,
+        np.sqrt((0.1 * 10) ** 2 + (0.2 * 20) ** 2 + (0.3 * 30) ** 2) / 60,
+        np.sqrt((0.1 * 10) ** 2 + (0.2 * 20) ** 2 + (0.3 * 30) ** 2 + (0.4 * 40) ** 2)
+        / 100,
+    ]
     assert result["Time"].tolist() == data["Time"]
     assert result["Value"].tolist() == expected_values
+    assert result["Error"].tolist() == expected_error
 
     result = cumulative_sum(df.copy(), column="Time")
     expected_values = [1, 3, 6, 10]
     assert result["Time"].tolist() == expected_values
     assert result["Value"].tolist() == data["Value"]
+    assert result["Error"].tolist() == data["Error"]


### PR DESCRIPTION
# Description

This pull request contains the following additions:
- Correction of the error propagation in the _groupby_ tally modifier. The current implementation takes into account that the original errors from the dataframe are relative errors and also returns the corresponding relative error. The error propagation is only applied when the action applied to the dataframe is _sum_ or _mean_; the _min_ and _max_ actions do not have an impact on the relative error of the original value.
- Addition of error propagation in the _cumulative_sum_ tally modifier. The implementation takes into account that the original errors from the dataframe are relative errors and also returns the corresponding relative error.
- Addition of TENDL 2017 as a dosimetry library ("17c").

No additional dependencies were introduced.

## Type of change

Please select what type of change this is.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New benchmark
    - [ ] Non-breaking change which entirely uses existing classes, structure etc
    - [ ] Breaking change which has implemented new/modified classes etc
- [x] New feature 
    - [x] Non-breaking change which adds functionality
    - [ ] Breaking change fix or feature that would cause existing functionality to not work as expected

## Other changes

- [ ] This change requires a documentation update
- [ ] (If Benchmark) This requires additional data that can be obtained from:
    - Benchmark data 1
    - Benchmark data 2

# Testing

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- The tests for the _groupby_ and _cumulative_sum_ were updated.
- All existing tests in JADE were run and successfully passed.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] General testing 
    - [x] New and existing unit tests pass locally with my changes
    - [x] Coverage is >80%