### PR TITLE
401 bug lib naming convention

### DIFF
--- a/src/jade/run/benchmark.py
+++ b/src/jade/run/benchmark.py
@@ -26,7 +26,6 @@ from jade.config.run_config import (
 from jade.helper.aux_functions import (
     CODE_CHECKERS,
     PathLike,
-    get_code_lib,
     get_jade_version,
     print_code_lib,
 )
@@ -165,7 +164,7 @@ class SingleRun(ABC):
         """
         run_command = self._build_command(env_vars)
         name, value = self._get_lib_data_command()
-        lib_data_command = f"export {name}={value}"
+        lib_data_command = f'export {name}="{value}"'
 
         flagnotrun = False
         if env_vars.run_mode == RunMode.JOB_SUMISSION:
@@ -269,9 +268,9 @@ class SingleRun(ABC):
                         f"Unable to find essential dummy variable {cmd} in job "
                         "script template, please check and re-run"
                     )
-            contents = contents.replace("INITIAL_DIR", str(directory))
-            contents = contents.replace("OUT_FILE", job_script + ".out")
-            contents = contents.replace("ERROR_FILE", job_script + ".err")
+            contents = contents.replace("INITIAL_DIR", f'"{str(directory)}"')
+            contents = contents.replace("OUT_FILE", f'"{job_script + ".out"}"')
+            contents = contents.replace("ERROR_FILE", f'"{job_script + ".err"}"')
             contents = contents.replace("MPI_TASKS", str(env_vars.mpi_tasks))
             contents = contents.replace("OMP_THREADS", str(env_vars.openmp_threads))
             contents = contents.replace("USER", user)
@@ -317,7 +316,7 @@ class SingleRunMCNP(SingleRun):
             tasks = "tasks " + str(omp_threads)
         else:
             tasks = ""
-        xsstring = f"xsdir={Path(self.lib.path).name}"
+        xsstring = f'xsdir="{Path(self.lib.path).name}"'
 
         run_command = [executable, inputstring, outputstring, xsstring, tasks]
 

--- a/tests/run/test_benchmark.py
+++ b/tests/run/test_benchmark.py
@@ -106,7 +106,7 @@ class TestBenchmarkRun:
         assert "Dummy_continue1" not in command  # successful simulation
         assert "Dummy_continue2" in command  # correct simulation
         assert (
-            "srun -np 10 mcnp6.2 i=Dummy_continue2.i n=Dummy_continue2. xsdir=xsdir.txt tasks 10"
+            'srun -np 10 mcnp6.2 i=Dummy_continue2.i n=Dummy_continue2. xsdir="xsdir.txt" tasks 10'
             in command
         )
 
@@ -262,18 +262,20 @@ class TestSingleRunMCNP:
         command = single_run.run(env_vars, "dummy", test=True)
 
         assert command == (
-            "mpirun -np 5 mcnp6.2 i=name.i n=name. xsdir=xsdir.txt tasks 10 > dump.out"
+            'mpirun -np 5 mcnp6.2 i=name.i n=name. xsdir="xsdir.txt" tasks 10 > dump.out'
         )
 
         # test with no mpi
         env_vars.mpi_tasks = 1
         command = single_run.run(env_vars, "dummy", test=True)
-        assert command == "mcnp6.2 i=name.i n=name. xsdir=xsdir.txt tasks 10 > dump.out"
+        assert (
+            command == 'mcnp6.2 i=name.i n=name. xsdir="xsdir.txt" tasks 10 > dump.out'
+        )
 
         # test with no openmp
         env_vars.openmp_threads = 1
         command = single_run.run(env_vars, "dummy", test=True)
-        assert command == "mcnp6.2 i=name.i n=name. xsdir=xsdir.txt  > dump.out"
+        assert command == 'mcnp6.2 i=name.i n=name. xsdir="xsdir.txt"  > dump.out'
 
     def test_submit_job(self, env_vars, tmpdir):
         mock_input = MockInput()
@@ -285,6 +287,10 @@ class TestSingleRunMCNP:
 
         command = single_run.run(env_vars, tmpdir, test=True)
         assert "#!/bin/sh\n\n#SBATCH" in command
+        # avoid linux path breaking in case of lib names with spaces
+        assert '--workdir="' in command
+        assert '--output="' in command
+        assert '--error="' in command
 
 
 class MockLibrary:


### PR DESCRIPTION
# Description

Avoid errors when paths contain spaces in terminal/bash commands. This allows to have spaces in library names as intended.

Fixes #401

## Type of change

Please select what type of change this is.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New benchmark
    - [ ] Non-breaking change which entirely uses existing classes, structure etc
    - [ ] Breaking change which has implemented new/modified classes etc
- [ ] New feature 
    - [ ] Non-breaking change which adds functionality
    - [ ] Breaking change fix or feature that would cause existing functionality to not work as expected


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] General testing 
    - [ ] New and existing unit tests pass locally with my changes
    - [x] Coverage is >80%