### PR TITLE
Fix for Issue #369

### DIFF
--- a/src/jade/post/excel_routines.py
+++ b/src/jade/post/excel_routines.py
@@ -65,15 +65,44 @@ class Table(ABC):
 
         return df.reset_index()
 
+    @staticmethod
+    def _get_safe_name(sheet_name: str) -> str:
+        """Cuts name string down to length 32 or smaller.
+
+        Parameters
+        ----------
+        sheet_name : str
+            Input sheet name string
+
+        Returns
+        -------
+        sheet_name
+            Shortened sheet name string
+        """
+        if len(sheet_name) > MAX_SHEET_NAME_LEN:
+            sheet_name = sheet_name[:31]
+        return sheet_name
+
     def _add_sheet(
         self,
         sheet_name: str,
         df: pd.DataFrame,
-        apply_conditional: bool | dict = True,
+        apply_conditional: bool = True,
         title: str | None = None,
     ):
-        if len(sheet_name) > MAX_SHEET_NAME_LEN:
-            sheet_name = sheet_name[:31]
+        """Function to add a worksheet ffrom pandas dataframe
+
+        Parameters
+        ----------
+        sheet_name : str
+            Name of sheet
+        df : pd.DataFrame
+            Pandas dataframe containing sheet data
+        apply_conditional : bool, optional
+            Set to true to apply conditional formatting
+        title : str | None, optional
+            Sheet title
+        """
         ws = self.writer.book.add_worksheet(sheet_name)
         if title is None:
             title = sheet_name
@@ -82,17 +111,14 @@ class Table(ABC):
         if self.cfg.change_col_names:
             self._rename_columns(df, self.cfg.change_col_names)
         df.to_excel(self.writer, sheet_name=sheet_name, startrow=DF_START_ROW)
+
         # additional operation on the sheet
-        if apply_conditional is not False and self.cfg.conditional_formatting:
-            if apply_conditional == True:
-                conditional_formatting = self.cfg.conditional_formatting
-            else:
-                conditional_formatting = apply_conditional
+        if apply_conditional and self.cfg.conditional_formatting:
             self.formatter.apply_conditional_formatting(
                 ws,
                 DF_START_ROW + df.columns.nlevels,
                 df.index.nlevels - 1,
-                conditional_formatting,
+                self.cfg.conditional_formatting,
             )
         # put the scientific formatter for all numbers
         self.formatter.apply_scientific_formatting(
@@ -107,7 +133,9 @@ class Table(ABC):
     def add_sheets(self):
         """Add the comparison sheets to the workbook."""
         dfs = self._get_sheet()
-        sheet_name = f"{self.cfg.comparison_type.value} {self.cfg.name}"
+        sheet_name = self._get_safe_name(
+            f"{self.cfg.comparison_type.value} {self.cfg.name}"
+        )
         title = f"{sheet_name} - {self.ref_tag} vs {self.target_tag}"
         self._add_sheet(sheet_name, dfs[0], apply_conditional=True, title=title)
 
@@ -115,9 +143,16 @@ class Table(ABC):
             for df, val, tag in zip(
                 [dfs[1], dfs[2]], ["ref", "target"], [self.ref_tag, self.target_tag]
             ):
-                sheet_name = f"{val} rel. err. {self.cfg.name}"
+                sheet_name = self._get_safe_name(f"{val} rel. err. {self.cfg.name}")
                 title = f"{tag} Relative Error for {self.cfg.name}"
-                self._add_sheet(sheet_name, df, apply_conditional=ERRORS_THRESHOLD, title=title)
+                self._add_sheet(sheet_name, df, title=title)
+                # apply standard formatting for error sheets
+                self.formatter.apply_conditional_formatting(
+                    self.writer.book.get_worksheet_by_name(sheet_name),
+                    DF_START_ROW + df.columns.nlevels,
+                    df.index.nlevels - 1,
+                    ERRORS_THRESHOLD,
+                )
 
     @abstractmethod
     def _get_sheet(self) -> list[pd.DataFrame]:

--- a/src/jade/post/excel_routines.py
+++ b/src/jade/post/excel_routines.py
@@ -80,7 +80,7 @@ class Table(ABC):
             Shortened sheet name string
         """
         if len(sheet_name) > MAX_SHEET_NAME_LEN:
-            sheet_name = sheet_name[:31]
+            sheet_name = sheet_name[:MAX_SHEET_NAME_LEN]
         return sheet_name
 
     def _add_sheet(
@@ -90,7 +90,7 @@ class Table(ABC):
         apply_conditional: bool = True,
         title: str | None = None,
     ):
-        """Function to add a worksheet ffrom pandas dataframe
+        """Function to add a worksheet from pandas dataframe
 
         Parameters
         ----------

--- a/tests/dummy_structure/cfg/benchmarks_pp/excel/Sphere.yaml
+++ b/tests/dummy_structure/cfg/benchmarks_pp/excel/Sphere.yaml
@@ -1,4 +1,4 @@
-comparison %:
+A long name that will break the excel sheets:
   results:
     - Leakage neutron flux
     - Leakage photon flux

--- a/tests/post/test_excel_processor.py
+++ b/tests/post/test_excel_processor.py
@@ -15,6 +15,15 @@ ROOT_RAW = files(tests.dummy_structure).joinpath("raw_data")
 
 
 class TestExcelProcessor:
+    def test_table_name(self, tmpdir):
+        with as_file(
+             files(tests.dummy_structure).joinpath("cfg/benchmarks_pp/excel/Sphere.yaml")
+        ) as file:
+            cfg = ConfigExcelProcessor.from_yaml(file)
+        codelibs = [("mcnp", "ENDFB-VIII.0"), ("mcnp", "FENDL 3.2c")]
+        processor = ExcelProcessor(ROOT_RAW, tmpdir, cfg, codelibs)
+        processor.process()       
+    
     def test_process(self, tmpdir):
         with as_file(
             files(default_cfg).joinpath("benchmarks_pp/excel/Sphere.yaml")

--- a/tests/post/test_excel_routines.py
+++ b/tests/post/test_excel_routines.py
@@ -7,6 +7,12 @@ from jade.post.excel_routines import ChiTable, Table
 
 
 class TestTable:
+    def test_get_dafe_name(self):
+        sheet_name = Table._get_safe_name(
+            "Some really long sheet name which is over 32 charaters"
+        )
+        assert len(sheet_name) < 32
+
     def test_compare(self):
         data1 = {"Energy": [1, 2, 3], "Value": [10, 20, 30], "Error": [0.1, 0.2, 0.3]}
         data2 = {"Energy": [1, 2, 3], "Value": [5, 15, 30], "Error": [0.15, 0.25, 0.35]}

--- a/tests/post/test_excel_routines.py
+++ b/tests/post/test_excel_routines.py
@@ -7,7 +7,7 @@ from jade.post.excel_routines import ChiTable, Table
 
 
 class TestTable:
-    def test_get_dafe_name(self):
+    def test_get_safe_name(self):
         sheet_name = Table._get_safe_name(
             "Some really long sheet name which is over 32 charaters"
         )


### PR DESCRIPTION
# Description

In `src/jade/post/excel_routines.py`, `Table.add_sheets()` and `Table.__add_sheet` has been refactored, to ensure that sheet name lengths are restricted to 32 characters, and also, sheet names are consistent between results sheets and error sheets when conditional formatting is applied.

Fixes #369

## Type of change

Please select what type of change this is.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New benchmark
    - [ ] Non-breaking change which entirely uses existing classes, structure etc
    - [ ] Breaking change which has implemented new/modified classes etc
- [ ] New feature 
    - [ ] Non-breaking change which adds functionality
    - [ ] Breaking change fix or feature that would cause existing functionality to not work as expected

## Other changes

None

# Testing

An additional test has been added, to check sheet names are cut down to 32 characters.

- `tests/post/test_excel__processor :: test_table_name`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] General testing 
    - [x] New and existing unit tests pass locally with my changes
    - [x] Coverage is >80%

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Enforces maximum Excel sheet name lengths and safely truncates long names.
  - Applies standard conditional formatting to error sheets immediately after creation.

- Tests
  - Added tests validating sheet-name truncation and end-to-end processing with long table names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->