### PR TITLE
Introduce a "force" option in the raw processing in order to allow for results overriding

### DIFF
--- a/docs/source/usage/postprocessing.rst
+++ b/docs/source/usage/postprocessing.rst
@@ -19,7 +19,12 @@ This command will scan all available simulation results and produce the raw data
 those simulations for wich the data was not generated yet. These files are stored in the
 ``raw_data`` folder in the root directory of the project. Their format are simple .csv tables.
 
-These files are the interface between the results processing which is transport code dependent
+It is possible to force the re-generation of the raw data for all successful simulations
+(independently if the raw data was already generated or not) by running:
+
+| ``jade --raw force``
+
+These raw results are the interface between the results processing which is transport code dependent
 and the post-processing which is transport code independent. This means that the user is free
 to build its own post-processing in case the one provided by JADE are not sufficient. A file
 is produced for each result (i.e. a nuclear response) in each benchmark run. 

--- a/docs/source/usage/utilities.rst
+++ b/docs/source/usage/utilities.rst
@@ -13,7 +13,7 @@ These can be executed using the utilities module of jade:
 
 or 
 
-    | ``python -m jade.utilitis --<option>``
+    | ``python -m jade.utilities --<option>``
 
 The following is a list of the available utilities:
 

--- a/src/jade/__main__.py
+++ b/src/jade/__main__.py
@@ -6,7 +6,13 @@ from jade.app.app import JadeApp
 def main():
     parser = argparse.ArgumentParser(description="JADE V&V")
     parser.add_argument("--run", help="run benchmarks", action="store_true")
-    parser.add_argument("--raw", help="process raw results", action="store_true")
+    parser.add_argument(
+        "--raw",
+        help="process raw results (optionally specify 'force')",
+        nargs="?",
+        const=True,
+        default=False,
+    )
     parser.add_argument(
         "--pp", help="perform complete post-process of the results", action="store_true"
     )
@@ -34,7 +40,13 @@ def main():
     if args.run:
         app.run_benchmarks()
     if args.raw:
-        app.raw_process()
+        if args.raw == "force":
+            force = True
+        if isinstance(args.raw, str) and args.raw != "force":
+            raise ValueError("Invalid argument for --raw. Use 'force' or leave empty.")
+        else:
+            force = False
+        app.raw_process(force=force)
     if args.pp:
         app.post_process()
     if args.cnt:

--- a/src/jade/__main__.py
+++ b/src/jade/__main__.py
@@ -42,7 +42,7 @@ def main():
     if args.raw:
         if args.raw == "force":
             force = True
-        if isinstance(args.raw, str) and args.raw != "force":
+        elif isinstance(args.raw, str) and args.raw != "force":
             raise ValueError("Invalid argument for --raw. Use 'force' or leave empty.")
         else:
             force = False

--- a/tests/app/test_app.py
+++ b/tests/app/test_app.py
@@ -58,6 +58,10 @@ class TestJadeApp:
         app.raw_process(subset=["Oktavian"])
         assert os.path.getmtime(filepath) == initial_mod_time
 
+        # finally try the force option and check that the file was overridden
+        app.raw_process(subset=["Oktavian"], force=True)
+        assert os.path.getmtime(filepath) > initial_mod_time
+
     def test_post_process(self, tmpdir):
         app = JadeApp(root=DUMMY_ROOT, skip_init=True)
         # override the post processor folder


### PR DESCRIPTION
# Description

A 'force' optional parameter as been added to the --raw option that allows to force the overriding of previously processed successful simulations.

Fixes #422

## Type of change

Please select what type of change this is.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New benchmark
    - [ ] Non-breaking change which entirely uses existing classes, structure etc
    - [ ] Breaking change which has implemented new/modified classes etc
- [x] New feature 
    - [x] Non-breaking change which adds functionality
    - [ ] Breaking change fix or feature that would cause existing functionality to not work as expected

## Other changes

- [x] This change requires a documentation update
- [ ] (If Benchmark) This requires additional data that can be obtained from:
    - Benchmark data 1
    - Benchmark data 2

# Testing

Added a suitable CI test

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] General testing 
    - [x] New and existing unit tests pass locally with my changes
    - [x] Coverage is >80%

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * CLI now supports forcing raw data regeneration for all successful simulations via --raw force.
* Documentation
  * Added instructions and examples for forcing raw data regeneration.
  * Corrected command reference to use python -m jade.utilities.
* Tests
  * Added test coverage validating overwrite behavior when forcing raw data regeneration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->