### PR TITLE
Ignore SSL certificate warning

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -78,6 +78,7 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           set -o pipefail
+          git config --global http.sslBackend schannel
           source /usr/local/Modules/init/sh
           pytest --cov=. -cov-config=jade.coveragerc --cov-report xml
         env:
@@ -89,6 +90,7 @@ jobs:
       - name: Testing - Windows
         if: runner.os == 'Windows'
         run: |
+          git config --global http.sslBackend schannel
           pytest
         env:
           ACCESS_TOKEN_GITHUB: ${{ secrets.ACCESS_TOKEN_GITHUB }}


### PR DESCRIPTION
Ignore the SSL certificate to allow the GitLab fetching

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated testing infrastructure configuration to improve cross-platform test execution.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->