### PR TITLE
skip gitlab fetch test on CI

### DIFF
--- a/tests/app/test_fetch.py
+++ b/tests/app/test_fetch.py
@@ -51,7 +51,10 @@ def test_wrong_fetch_f4e_inputs(tmpdir):
     assert not success
 
 
-@pytest.mark.skipif(F4E_GITLAB_TOKEN is None, reason="No token found")
+@pytest.mark.skipif(
+    F4E_GITLAB_TOKEN is None or os.environ.get("GITHUB_ACTIONS") == "true",
+    reason="No token found or running on GitHub CI"
+)
 def test_fetch_f4e_inputs(tmpdir):
     assert F4E_GITLAB_TOKEN is not None
     # test correct fetching in an empty folder


### PR DESCRIPTION
I believe there are problems from F4E IT side. It is not worth to block all development for this, test will be skipped on CI, still running locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test skip conditions to exclude tests when running in GitHub Actions CI environment or when authentication token is unavailable.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->