### PR TITLE
Fixing error handling bug outlined in issue 479

### DIFF
--- a/src/jade/post/manipulate_tally.py
+++ b/src/jade/post/manipulate_tally.py
@@ -342,11 +342,6 @@ def volume(tally: pd.DataFrame, volumes: dict[int, float]) -> pd.DataFrame:
                 tally["Value"] / volumes[cell],
                 tally["Value"],
             )
-            tally["Error"] = np.where(
-                (tally["Cells"] == cell),
-                tally["Error"] / volumes[cell],
-                tally["Error"],
-            )
     return tally
 
 
@@ -372,11 +367,6 @@ def mass(tally: pd.DataFrame, masses: dict[int, float]) -> pd.DataFrame:
                 (tally["Cells"] == cell),
                 tally["Value"] / masses[cell],
                 tally["Value"],
-            )
-            tally["Error"] = np.where(
-                (tally["Cells"] == cell),
-                tally["Error"] / masses[cell],
-                tally["Error"],
             )
     return tally
 

--- a/tests/post/test_manipulate_tally.py
+++ b/tests/post/test_manipulate_tally.py
@@ -403,4 +403,4 @@ def test_mass():
     masses = {1: 2.0, 2: 2.0, 3: 2.0, 4: 2.0, 5: 2.0}
     result = mass(df, masses)
     assert 3.65062e-06 == pytest.approx(result["Value"][0], rel=1e-5)
-    assert 0.05 == pytest.approx(result["Error"][0], rel=1e-5)
+    assert 0.1 == pytest.approx(result["Error"][0], rel=1e-5)

--- a/tests/post/test_manipulate_tally.py
+++ b/tests/post/test_manipulate_tally.py
@@ -390,7 +390,7 @@ def test_volume():
     volumes = {1: 2.0, 2: 2.0, 3: 2.0, 4: 2.0, 5: 2.0}
     result = volume(df, volumes)
     assert 3.65062e-06 == pytest.approx(result["Value"][0], rel=1e-5)
-    assert 0.05 == pytest.approx(result["Error"][0], rel=1e-5)
+    assert 0.1 == pytest.approx(result["Error"][0], rel=1e-5)
 
 
 def test_mass():


### PR DESCRIPTION
Bug fix for #479.

Removed the lines that was dividing the relative errors by mass/volume.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected per-cell normalization so reported error values are no longer altered during value normalization, yielding consistent error reporting.

* **Tests**
  * Updated unit test expectations to reflect the corrected error values for volume and mass normalization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->