### PR TITLE
Issue with FNG-HCPB post-processing

### DIFF
--- a/src/jade/post/manipulate_tally.py
+++ b/src/jade/post/manipulate_tally.py
@@ -72,7 +72,7 @@ def condense_groups(
     tally["coarse_bin"] = pd.cut(tally[group_column], bins=bins, right=False)
     tally = tally.drop(columns=[group_column])
     tally[group_column] = tally["coarse_bin"].apply(
-        lambda x: f"{x.left:g} - {x.right:g}" if pd.notna(x) else "NaN"
+        lambda x: f"{x.left:g} - {x.right:g}" if pd.notna(x) else np.nan
     )
     '''
     labels = [f"{bins[i]:g} - {bins[i+1]:g}" for i in range(len(bins) - 1)]

--- a/src/jade/post/manipulate_tally.py
+++ b/src/jade/post/manipulate_tally.py
@@ -68,10 +68,22 @@ def condense_groups(
     """
     tally["abs err"] = tally["Error"] * tally["Value"]
     # this divides the entries in coarse energy bins
+
     tally["coarse_bin"] = pd.cut(tally[group_column], bins=bins, right=False)
+    tally = tally.drop(columns=[group_column])
     tally[group_column] = tally["coarse_bin"].apply(
-        lambda x: f"{x.left:g} - {x.right:g}"
+        lambda x: f"{x.left:g} - {x.right:g}" if pd.notna(x) else "NaN"
     )
+    '''
+    labels = [f"{bins[i]:g} - {bins[i+1]:g}" for i in range(len(bins) - 1)]
+
+    tally[group_column] = pd.cut(
+        tally[group_column],
+        bins=bins,
+        right=False,
+        labels=labels,
+    )
+    '''
     del tally["coarse_bin"]
     grouped = tally.groupby(group_column, observed=False).agg(
         {"Value": "sum", "abs err": lambda x: math.sqrt((x**2).sum())}

--- a/src/jade/resources/default_cfg/benchmarks_pp/raw/openmc/FNG-HCPB.yaml
+++ b/src/jade/resources/default_cfg/benchmarks_pp/raw/openmc/FNG-HCPB.yaml
@@ -126,14 +126,12 @@ Reaction rate:
 Tritium activity:
   concat_option: no_action
   84: 
-      - [mass, {}]
       - [scale, {'factor': 2.57042574E+07}]
       - [replace, {'column': 'Cells', 'values': *depth_h3}]
 
 Tritium activity Pellet:
   concat_option: no_action
   84: 
-      - [mass, {}]
       - [scale, {'factor': 2.57042574E+07}]
       - [add_column_with_dict, {'ref_column': 'Cells', 'values': *depth_h3d, new_columns: [ 'Distance','Pellet']}]
       - [replace, {'column': 'Cells', 'values': *depth_h3}]  


### PR DESCRIPTION
The mass factor was being accounted for twice as it was contained within the scale factor also. This pull request removes the mass divisor to resolve this issue. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Removed an unnecessary mass-transformation step from tritium activity processing in benchmark pipelines.
* **Bug Fixes**
  * Energy-bin labeling now handles missing/undefined intervals gracefully, avoiding invalid or misleading bin labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->