### PR TITLE
bumped f4enix version and fixed compatibility

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Install openmc (legacy)
         if: runner.os == 'Linux' && matrix.python-version == '3.11'
         run: |
-          pip install git+https://github.com/openmc-dev/openmc.git@v0.15.3#egg=openmc
+          pip install git+https://github.com/openmc-dev/openmc.git@3b5ac08bfb754ef93ff3db12fcda2ecbd0dbe464
       
       - name: Install openmc
         if: runner.os == 'Linux' && matrix.python-version != '3.10' && matrix.python-version != '3.11'

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -62,8 +62,14 @@ jobs:
         run: |
           pip install git+https://github.com/openmc-dev/openmc.git@v0.15.0#egg=openmc
       
+      # Cap version also for python 11
+      - name: Install openmc (legacy)
+        if: runner.os == 'Linux' && matrix.python-version == '3.11'
+        run: |
+          pip install git+https://github.com/openmc-dev/openmc.git@v0.15.3#egg=openmc
+      
       - name: Install openmc
-        if: runner.os == 'Linux' && matrix.python-version != '3.10'
+        if: runner.os == 'Linux' && matrix.python-version != '3.10' && matrix.python-version != '3.11'
         run: |
           pip install git+https://github.com/openmc-dev/openmc.git
 
@@ -98,8 +104,8 @@ jobs:
       
       # Upload coverage to Codecov. Do it only for one case of the matrix.
       - name: Upload coverage to Codecov
-        # do it only once for python 3.10
-        if: matrix.python-version == '3.11' && matrix.os == 'ubuntu-latest'
+        # do it only once for python 3.12
+        if: matrix.python-version == '3.12' && matrix.os == 'ubuntu-latest'
         uses: codecov/codecov-action@v4
         with:
           verbose: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "matplotlib",
     "aspose-words",
     "requests",
-    "f4enix >= 0.18.0",
+    "f4enix >= 0.19.0",
     "pyyaml",
     "seaborn",
     "python-gitlab"

--- a/src/jade/run/input.py
+++ b/src/jade/run/input.py
@@ -12,7 +12,7 @@ from f4enix.input.libmanager import LibManager
 from f4enix.input.materials import MatCardsList, Material, SubMaterial, Zaid
 from f4enix.input.MCNPinput import D1S_Input
 from f4enix.input.MCNPinput import Input as MCNPInput
-from f4enix.input.irradiation import Nuclide
+from f4enix.core.irradiation import Nuclide
 
 from jade.config.run_config import Library, LibraryD1S, LibraryMCNP
 from jade.helper.__optionals__ import OMC_AVAIL


### PR DESCRIPTION
Bump F4Enix version to 0.19.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped a core dependency to a newer compatible version.
  * Adjusted CI/test installation logic to better handle recent Python releases and related tooling.

* **Refactor**
  * Updated internal import paths; no changes to public APIs or user-facing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->