### PR TITLE
Increase default NPS for the Sphere and the Sphere SDDR

### DIFF
--- a/src/jade/resources/default_cfg/run_cfg.yml
+++ b/src/jade/resources/default_cfg/run_cfg.yml
@@ -7,7 +7,7 @@ Sphere:
     serpent: []
   custom_input: '10'
   description: Sphere Leakage
-  nps: 1e8
+  nps: 1e9
   only_input: false
 #
 ITER_1D:
@@ -73,7 +73,7 @@ SphereSDDR:
     serpent: []
   custom_input: '10'
   description: Sphere SDDR
-  nps: 1e8
+  nps: 1e9
   only_input: false
 #
 Simple_Tokamak:


### PR DESCRIPTION
This pull request applies an increase in the default NPS of the Sphere and the Sphere SDDR benchmarks from 1E8 to 1E9.
This change is applied to the `run_cfg.yml` file.

After the comparison between OpenMC (run with 1E8 particles) and MCNP (run with 1E9 particles) Sphere results, the benefit of applying this modification was highlighted. For example, for subcase `Sphere_68164_Er-164`:
<img width="1125" height="879" alt="image" src="https://github.com/user-attachments/assets/fe97989f-4dd1-4b19-acfb-c078cf57e3c0" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated benchmark configuration parameters to enhance testing consistency across specified configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->