### PR TITLE
Added TKINTER_AVAIL flag to gui tests

### DIFF
--- a/tests/gui/test_config_gui.py
+++ b/tests/gui/test_config_gui.py
@@ -2,18 +2,23 @@ from __future__ import annotations
 
 from importlib.resources import files
 from pathlib import Path
-from tkinter import filedialog, messagebox, ttk
 
 import pytest
-from ttkthemes import ThemedTk
 
 import jade.resources
-from jade.gui.run_config_gui import ConfigGUI
 from unittest.mock import patch
+
+from jade.helper.__optionals__ import TKINTER_AVAIL
+
+if TKINTER_AVAIL:
+    from tkinter import filedialog, messagebox, ttk
+    from ttkthemes import ThemedTk
+    from jade.gui.run_config_gui import ConfigGUI
+
 
 DEFAULT_CFG = files(jade.resources).joinpath("default_cfg")
 
-
+@pytest.mark.skipif(not TKINTER_AVAIL, reason="tkinter is not available")
 class TestConfigGui:
     @pytest.fixture(scope="session")
     def config_gui(self):
@@ -39,6 +44,7 @@ class TestConfigGui:
         # assert config_gui.notebook.tab(1, "text") == "Libraries"
         assert isinstance(config_gui.save_button, ttk.Button)
 
+    @pytest.mark.skipif(not TKINTER_AVAIL, reason="tkinter is not available")
     def test_save_settings(self, config_gui, monkeypatch, tmpdir):
         def mock_return_file(defaultextension=None, filetypes=None):
             return tmpdir.join("test_output.yml")

--- a/tests/gui/test_post_config_gui.py
+++ b/tests/gui/test_post_config_gui.py
@@ -5,14 +5,20 @@ from unittest.mock import patch
 
 import jade.resources
 from jade.config.status import GlobalStatus
-from jade.gui.post_config_gui import PostConfigGUI
 from tests import dummy_structure
+
+import pytest
+
+from jade.helper.__optionals__ import TKINTER_AVAIL
+
+if TKINTER_AVAIL:
+    from jade.gui.post_config_gui import PostConfigGUI
 
 DUMMY_STRUCT = files(dummy_structure)
 
 DEFAULT_CFG = files(jade.resources).joinpath("default_cfg")
 
-
+@pytest.mark.skipif(not TKINTER_AVAIL, reason="tkinter is not available")
 class TestPostConfigGui:
     def test_init(self):
         status = GlobalStatus(


### PR DESCRIPTION
Added a fix for gui tests running on systems without Tkinter installed. It will use the `@pytest.skipif` marker, using the `from jade.helper.__optionals__ import TKINTER_AVAIL` flag to determine if tkinter is available.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * GUI configuration tests now skip gracefully when GUI libraries are unavailable, improving test reliability across different environments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JADE-V-V/JADE/pull/518?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->