### PR TITLE
bump python versions and get automatic openmc tag

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -65,6 +65,7 @@ jobs:
           pip install git+https://github.com/openmc-dev/openmc.git@3b5ac08bfb754ef93ff3db12fcda2ecbd0dbe464
       
       - name: Get OpenMC latest tag
+        if: runner.os == 'Linux'
         id: openmc-tag
         run: |
           TAG=$(curl -s https://api.github.com/repos/openmc-dev/openmc/releases/latest | grep '"tag_name"' | sed -E 's/.*"([^"]+)".*/\1/')

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -11,12 +11,14 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, ubuntu-20.04, ubuntu-latest]
-        python-version: ["3.10", "3.11", '3.12']
+        python-version: ["3.11", '3.12', '3.13']
         full-test:
           - ${{ contains(github.ref, 'master') || contains(github.ref, 'main') || startsWith(github.ref, 'refs/heads/release') }}
         exclude:
           - full-test: false
             python-version: ["3.10"]
+          - full-test: false
+            python-version: ["3.11"]
           - full-test: false
             os: "ubuntu-20.04"
       fail-fast: false
@@ -56,22 +58,22 @@ jobs:
         run: |
           pip install -e .[dev,ui]
       
-      # Cap the openmc installation to 0.15.0 for older python
-      - name: Install openmc (legacy)
-        if: runner.os == 'Linux' && matrix.python-version == '3.10'
-        run: |
-          pip install git+https://github.com/openmc-dev/openmc.git@v0.15.0#egg=openmc
-      
-      # Cap version also for python 11
+      # Cap version of OpenMC for python 3.11
       - name: Install openmc (legacy)
         if: runner.os == 'Linux' && matrix.python-version == '3.11'
         run: |
           pip install git+https://github.com/openmc-dev/openmc.git@3b5ac08bfb754ef93ff3db12fcda2ecbd0dbe464
       
-      - name: Install openmc
-        if: runner.os == 'Linux' && matrix.python-version != '3.10' && matrix.python-version != '3.11'
+      - name: Get OpenMC latest tag
+        id: openmc-tag
         run: |
-          pip install git+https://github.com/openmc-dev/openmc.git
+          TAG=$(curl -s https://api.github.com/repos/openmc-dev/openmc/releases/latest | grep '"tag_name"' | sed -E 's/.*"([^"]+)".*/\1/')
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
+
+      - name: Install openmc
+        if: runner.os == 'Linux' && matrix.python-version != '3.11'
+        run: |
+          pip install git+https://github.com/openmc-dev/openmc.git@${{ steps.openmc-tag.outputs.tag }}
 
       # Install dependencies windows
       - name: Install dependencies Windows 

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -64,17 +64,18 @@ jobs:
         run: |
           pip install git+https://github.com/openmc-dev/openmc.git@3b5ac08bfb754ef93ff3db12fcda2ecbd0dbe464
       
-      - name: Get OpenMC latest tag
-        if: runner.os == 'Linux'
-        id: openmc-tag
-        run: |
-          TAG=$(curl -s https://api.github.com/repos/openmc-dev/openmc/releases/latest | grep '"tag_name"' | sed -E 's/.*"([^"]+)".*/\1/')
-          echo "tag=$TAG" >> $GITHUB_OUTPUT
+      # - name: Get OpenMC latest tag
+      #   if: runner.os == 'Linux'
+      #   id: openmc-tag
+      #   run: |
+      #     TAG=$(curl -s https://api.github.com/repos/openmc-dev/openmc/releases/latest | grep '"tag_name"' | sed -E 's/.*"([^"]+)".*/\1/')
+      #     echo "tag=$TAG" >> $GITHUB_OUTPUT
 
       - name: Install openmc
         if: runner.os == 'Linux' && matrix.python-version != '3.11'
+        # pip install git+https://github.com/openmc-dev/openmc.git@${{ steps.openmc-tag.outputs.tag }}
         run: |
-          pip install git+https://github.com/openmc-dev/openmc.git@${{ steps.openmc-tag.outputs.tag }}
+          pip install git+https://github.com/openmc-dev/openmc.git
 
       # Install dependencies windows
       - name: Install dependencies Windows 


### PR DESCRIPTION
Move the supported python versions to 3.11, 3.12 and 3.13.

At the same time, automatically get the latest OpenMC tag (stable release) for tests on linux.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD to test against Python 3.11, 3.12, and 3.13 (Python 3.10 no longer supported).
  * Updated OpenMC installation process for improved compatibility across Python versions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JADE-V-V/JADE/pull/522?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->