### PR TITLE
Fix OpenMC duplicated ID warning

### DIFF
--- a/src/jade/helper/openmc.py
+++ b/src/jade/helper/openmc.py
@@ -187,7 +187,7 @@ class OpenMCInputFiles:
         # Reset OpenMC global ID registries to avoid duplicate ID warnings
         # when creating multiple input instances from the same templates
         openmc.reset_auto_ids()
-        
+
         files = os.listdir(path)
         if ("geometry.xml" in files) and ("materials.xml") in files:
             self.load_geometry(
@@ -404,7 +404,15 @@ class OpenMCInputFiles:
             weight_windows_outfile = os.path.join(path, "weight_windows.h5")
             shutil.copyfile(self.weight_windows_file, weight_windows_outfile)
             self.settings.weight_windows_on = True
-            self.settings.weight_windows = openmc.hdf5_to_wws(weight_windows_outfile)
+            try:
+                self.settings.weight_windows = openmc.WeightWindowsList.from_hdf5(
+                    weight_windows_outfile
+                )
+            except AttributeError:
+                # Older versions than 0.15.3 still have this deprecated functio
+                self.settings.weight_windows = openmc.hdf5_to_wws(
+                    weight_windows_outfile
+                )
         model = openmc.Model(
             geometry=self.geometry, settings=self.settings, tallies=self.tallies
         )

--- a/src/jade/helper/openmc.py
+++ b/src/jade/helper/openmc.py
@@ -184,6 +184,10 @@ class OpenMCInputFiles:
         -------
         None
         """
+        # Reset OpenMC global ID registries to avoid duplicate ID warnings
+        # when creating multiple input instances from the same templates
+        openmc.reset_auto_ids()
+        
         files = os.listdir(path)
         if ("geometry.xml" in files) and ("materials.xml") in files:
             self.load_geometry(


### PR DESCRIPTION
OpenMC maintains global registries of objects (Materials, Surfaces, Cells, etc.) indexed by their IDs. When inputs are instantiated sequentially:
- loads geometry files or creates materials with IDs 3, 4, 5, etc. → Objects registered globally
- loads the same files or creates objects with the same IDs → OpenMC warns: "Already exists!"

The warnings appear because OpenMC's global registries are not cleared between input creations.

Resetting these IDs at the beginning of each intialization should solve the issue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed duplicate auto-ID warnings when creating multiple instances from shared templates.

* **Improvements**
  * Enhanced compatibility with different OpenMC versions by supporting both current and legacy weight-window output formats.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JADE-V-V/JADE/pull/523?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->