### PR TITLE
517 bug   jade instantiation fetch

### DIFF
--- a/src/jade/app/fetch.py
+++ b/src/jade/app/fetch.py
@@ -149,7 +149,9 @@ def _install_standard_folder_structure(
         _install_data(fetched_folder, install_folder)
 
     # Once done, delete the src folder
-    shutil.rmtree(os.path.join(tempfile.gettempdir(), "extracted"))
+    extracted_root = Path(extracted_folder).parent
+    if extracted_root.exists() and extracted_root.name == "extracted":
+        shutil.rmtree(extracted_root)
 
     return True
 

--- a/src/jade/app/fetch.py
+++ b/src/jade/app/fetch.py
@@ -149,7 +149,7 @@ def _install_standard_folder_structure(
         _install_data(fetched_folder, install_folder)
 
     # Once done, delete the src folder
-    shutil.rmtree(os.path.join(extracted_folder))
+    shutil.rmtree(os.path.join(tempfile.gettempdir(), "extracted"))
 
     return True
 

--- a/src/jade/app/fetch.py
+++ b/src/jade/app/fetch.py
@@ -62,7 +62,8 @@ def _extract_zip(zip_content, dest: PathLike) -> PathLike:
     with zipfile.ZipFile(tmp_zip, "r") as zip_ref:
         main_folder_name = zip_ref.namelist()[0]
         zip_ref.extractall(extracted_folder)
-
+    # Delete the zip file
+    os.remove(tmp_zip)
     return Path(extracted_folder, main_folder_name)
 
 
@@ -122,7 +123,6 @@ def _install_data(fetch_folder: str | os.PathLike, install_folder: str | os.Path
             os.path.join(install_folder, item),
         )
 
-
 def _install_standard_folder_structure(
     extracted_folder: str | os.PathLike,
     inputs_root: PathLike,
@@ -149,7 +149,7 @@ def _install_standard_folder_structure(
         _install_data(fetched_folder, install_folder)
 
     # Once done, delete the src folder
-    shutil.rmtree(extracted_folder)
+    shutil.rmtree(os.path.join(extracted_folder))
 
     return True
 

--- a/tests/app/test_fetch.py
+++ b/tests/app/test_fetch.py
@@ -26,6 +26,7 @@ def test_fetch_iaea_inputs(tmpdir):
     assert success
     assert len(os.listdir(inp_path)) > 0
     assert len(os.listdir(exp_path)) > 0
+    assert not os.path.exists(os.path.join(tmpdir, "extracted"))
 
     # # check failed authentication (this can be used later for gitlab)
     # # try to get the token from local secret file
@@ -66,6 +67,7 @@ def test_fetch_f4e_inputs(tmpdir):
     success = fetch_f4e_inputs(inp_path, F4E_GITLAB_TOKEN)
     assert success
     assert len(os.listdir(inp_path)) > 0
+    assert not os.path.exists(os.path.join(tmpdir, "extracted"))
 
 
 def test_fetch_f4e_exp_data(tmpdir):
@@ -79,3 +81,4 @@ def test_fetch_f4e_exp_data(tmpdir):
     success = fetch_nonIAEA_exp_data(exp_path)
     assert success
     assert len(os.listdir(exp_path)) > 0
+    assert not os.path.exists(os.path.join(tmpdir, "extracted"))

--- a/tests/app/test_fetch.py
+++ b/tests/app/test_fetch.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import tempfile
 
 import pytest
 
@@ -26,7 +27,7 @@ def test_fetch_iaea_inputs(tmpdir):
     assert success
     assert len(os.listdir(inp_path)) > 0
     assert len(os.listdir(exp_path)) > 0
-    assert not os.path.exists(os.path.join(tmpdir, "extracted"))
+    assert not os.path.exists(os.path.join(tempfile.gettempdir(), "extracted"))
 
     # # check failed authentication (this can be used later for gitlab)
     # # try to get the token from local secret file
@@ -67,7 +68,7 @@ def test_fetch_f4e_inputs(tmpdir):
     success = fetch_f4e_inputs(inp_path, F4E_GITLAB_TOKEN)
     assert success
     assert len(os.listdir(inp_path)) > 0
-    assert not os.path.exists(os.path.join(tmpdir, "extracted"))
+    assert not os.path.exists(os.path.join(tempfile.gettempdir(), "extracted"))
 
 
 def test_fetch_f4e_exp_data(tmpdir):
@@ -81,4 +82,4 @@ def test_fetch_f4e_exp_data(tmpdir):
     success = fetch_nonIAEA_exp_data(exp_path)
     assert success
     assert len(os.listdir(exp_path)) > 0
-    assert not os.path.exists(os.path.join(tmpdir, "extracted"))
+    assert not os.path.exists(os.path.join(tempfile.gettempdir(), "extracted"))


### PR DESCRIPTION
Fixes issue #517. Solved by adding an `os.remove(tmp_zip)` command to delete the zip file after it has been extracted. In addition, the `shutil.rmtree()` command in `def _install_standard_folder_structure()` has been modified, to delete the root `extracted` folder rather than the subdirectories contained within it. Existing tests in `tests/app/test_fetch.py` have been mofidied to ensure the `extracted` folder is always removed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup of temporary files and extracted folders after data fetches, preventing leftover zip files and temporary directories on the system.
* **Tests**
  * Added assertions to verify extraction routines do not leave temporary extracted directories behind, strengthening validation of cleanup behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JADE-V-V/JADE/pull/524?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->