### PR TITLE
skip only inputs in the generation of global command

### DIFF
--- a/src/jade/run/benchmark.py
+++ b/src/jade/run/benchmark.py
@@ -947,6 +947,8 @@ def launch_global_jobs(
     # first organize the different commands by code
     commands_by_code: dict[CODE, list[tuple[list[str], PathLike]]] = {}
     for code, command, folder in commands:
+        if not command:  # skip only inputs
+            continue
         if code not in commands_by_code:
             commands_by_code[code] = []
         commands_by_code[code].append((command, folder))

--- a/tests/app/test_app.py
+++ b/tests/app/test_app.py
@@ -57,6 +57,24 @@ class TestJadeApp:
         assert len(commands) == 1
         assert commands[0].count("cd ") == 4
 
+    def test_only_input_global(self, tmpdir, monkeypatch):
+        # override the simulation root folder
+        app = JadeApp(root=DUMMY_ROOT, skip_init=True)
+        # override the simulation root folder
+        app.tree.simulations = tmpdir
+        # change the run config to job submission
+        app.run_cfg.env_vars.run_mode = RunMode.GLOBAL_JOB
+        # set the only input to false in all benchmarks
+        for bench in app.run_cfg.benchmarks.values():
+            bench.only_input = True
+            # Mock the lib.path to a valid string
+            for code, lib in bench.run:
+                lib.path = RUN_RES.joinpath("xsdir.txt")
+        monkeypatch.setattr("builtins.input", lambda _: "y")
+
+        # do not raise error due to empty command
+        app.run_benchmarks(testing=True)
+
     def test_raw_process(self, tmpdir):
         app = JadeApp(root=DUMMY_ROOT, skip_init=True)
         # override the raw processor folder


### PR DESCRIPTION
Fix #510 

During the generation of global job command the "only_input" None command were trying to be added causing the error. Now this is skipped and a test has been added to the CI to verify the fix.