### PR TITLE
use uncertainty band for experimental data

### DIFF
--- a/src/jade/post/plotter.py
+++ b/src/jade/post/plotter.py
@@ -441,14 +441,29 @@ class BinnedPlot(Plot):
                     where="pre",
                 )
                 newX = _get_error_x_pos(x)
-                ax1.errorbar(
-                    newX,
-                    y[1:],
-                    linewidth=0,
-                    yerr=err_multi,
-                    elinewidth=0.5,
-                    color=COLORS[idx],
-                )
+
+                # For the first library (reference/experimental), use filled error band
+                if idx == 0 and codelib == "exp - exp":
+                    y_upper = np.concatenate(([0], y[1:] + err_multi))
+                    y_lower = np.concatenate(([0], y[1:] - err_multi))
+                    ax1.fill_between(
+                        x,
+                        y_lower,
+                        y_upper,
+                        color=COLORS[idx],
+                        alpha=0.2,
+                        step="pre",
+                    )
+                else:
+                    # For other libraries, keep error bars
+                    ax1.errorbar(
+                        newX,
+                        y[1:],
+                        linewidth=0,
+                        yerr=err_multi,
+                        elinewidth=0.5,
+                        color=COLORS[idx],
+                    )
                 # add a label if needed (only one per group)
                 if subcases and idx == 0:
                     lbl = subcases[1][i]
@@ -488,6 +503,18 @@ class BinnedPlot(Plot):
                     linestyle=linestyle,
                     linewidth=linewidth,
                     where="pre",
+                )
+            elif idx == 0 and plot_CE:
+                # print error band
+                y_upper = 1 + err_multi
+                y_lower = 1 - err_multi
+                CE_ax.fill_between(
+                    df[self.cfg.x].values,
+                    y_lower,
+                    y_upper,
+                    color=COLORS[idx],
+                    alpha=0.2,
+                    step="pre",
                 )
 
         # Final operations

--- a/src/jade/post/plotter.py
+++ b/src/jade/post/plotter.py
@@ -506,8 +506,9 @@ class BinnedPlot(Plot):
                 )
             elif idx == 0 and plot_CE:
                 # print error band
-                y_upper = 1 + err_multi
-                y_lower = 1 - err_multi
+                rel_err = np.array(df["Error"])
+                y_upper = 1 + rel_err
+                y_lower = 1 - rel_err
                 CE_ax.fill_between(
                     df[self.cfg.x].values,
                     y_lower,


### PR DESCRIPTION
Fix #409 

Use error bands instead of error bars for binned plots with experimental data

<img width="1125" height="888" alt="image" src="https://github.com/user-attachments/assets/b4d497d1-d2e5-4060-8d6f-6e27b3181729" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated uncertainty visuals on reference experimental plots: filled error bands now replace stepped error bars for clearer uncertainty depiction.
  * Improved uncertainty rendering in comparative (CE) plots by adding consistent filled reference bands for better visual consistency across plots.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JADE-V-V/JADE/pull/529?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->