### PR TITLE
Feature/open mc sphere output

### DIFF
--- a/src/jade/helper/openmc.py
+++ b/src/jade/helper/openmc.py
@@ -500,7 +500,7 @@ class OpenMCStatePoint:
         for column in df.columns:
             if "[eV]" in column:
                 df[column] *= 1e-6
-        if ("heating" or "damage-energy") in df["score"].values:
+        if df["score"].isin(["heating", "damage-energy"]).any():
             df["mean"] = np.where(
                 (df["score"] == "heating") | (df["score"] == "damage-energy"),
                 1e-6 * df["mean"],

--- a/src/jade/post/raw_processor.py
+++ b/src/jade/post/raw_processor.py
@@ -9,7 +9,7 @@ from jade.config.raw_config import ConfigRawProcessor, TallyModOption
 from jade.helper.aux_functions import PathLike, get_jade_version
 from jade.helper.constants import CODE
 from jade.post.manipulate_tally import CONCAT_FUNCTIONS, MOD_FUNCTIONS
-from jade.post.sim_output import MCNPSimOutput, OpenMCSimOutput
+from jade.post.sim_output import MCNPSimOutput, OpenMCSimOutput, OpenMCSphereSimOutput
 
 logger = logging.getLogger(__name__)
 
@@ -54,7 +54,10 @@ class RawProcessor:
         if self.code in (CODE.MCNP, CODE.D1S):
             self.sim_output = MCNPSimOutput(sim_folder)
         elif self.code == CODE.OPENMC:
-            self.sim_output = OpenMCSimOutput(sim_folder)
+            if self.metadata.get("benchmark_name") =="Sphere":
+                self.sim_output = OpenMCSphereSimOutput(sim_folder)
+            else:
+                self.sim_output = OpenMCSimOutput(sim_folder)
         else:
             raise NotImplementedError(
                 f"Code {self.code} not implemented yet for raw data processing"

--- a/src/jade/post/sim_output.py
+++ b/src/jade/post/sim_output.py
@@ -481,7 +481,6 @@ class OpenMCSphereSimOutput(OpenMCSimOutput):
         self._tallydata, self._totalbin = self._process_tally()
         self.stat_checks = None
 
-        
     def _create_dataframes(
         self, tallies: dict
     ) -> tuple[dict[int, pd.DataFrame], dict[int, pd.DataFrame]]:
@@ -528,7 +527,8 @@ class OpenMCSphereSimOutput(OpenMCSimOutput):
 
             # If tally is Sphere, and is tally 14,24,34 then need to normalise by atomic density
             # Need to generate atomic density for a given Sphere input
-            if id in [14, 24, 34]:
+            RR_tally_IDs = [14, 24, 34]
+            if id in RR_tally_IDs:
                 sorted_tally["Value"] = sorted_tally["Value"] / self.atomic_density
                 sorted_tally["Error"] = sorted_tally["Error"] / self.atomic_density
             else:
@@ -540,7 +540,6 @@ class OpenMCSphereSimOutput(OpenMCSimOutput):
             tallydata[id] = sorted_tally
             totalbin[id] = None
         return tallydata, totalbin
-
 
 def _remove_constant_columns(df: pd.DataFrame) -> pd.DataFrame:
     """eliminate unnecessary columns from OpenMC tally data"""

--- a/src/jade/post/sim_output.py
+++ b/src/jade/post/sim_output.py
@@ -357,6 +357,22 @@ class OpenMCSimOutput(AbstractSimOutput):
         return statepoint_found
     
     def _prep_tally(self, filter_lookup, tally: pd.DataFrame) -> None:
+        '''
+        Function to prepare the tally dataframe for JADE formatting, by renaming the columns and sorting by the filters.
+        
+        Parameters
+        ----------
+        filter_lookup : dict
+            Dictionary to map OpenMC filter names to JADE column names
+        tally : pd.DataFrame
+            The OpenMC tally dataframe to be prepared for JADE formatting
+
+        Returns
+        -------
+        sorted_tally : pd.DataFrame
+            The sorted and renamed tally dataframe ready for JADE formatting
+
+        '''
         filters = []
         new_columns = {}
         if "cell" in tally.columns:

--- a/src/jade/post/sim_output.py
+++ b/src/jade/post/sim_output.py
@@ -491,11 +491,7 @@ class OpenMCSphereSimOutput(OpenMCSimOutput):
         atomic_densities = materials[1].get_nuclide_atom_densities()
         self.atomic_density = sum(atomic_densities.values())
 
-        self.output = omc.OpenMCStatePoint(statefile, volfile)
-        self._tally_numbers = self.output.tally_numbers
-        self._tally_comments = self.output.tally_comments
-        self._tallydata, self._totalbin = self._process_tally()
-        self.stat_checks = None
+        super().__init__(sim_folder)
 
     def _create_dataframes(
         self, tallies: dict

--- a/src/jade/post/sim_output.py
+++ b/src/jade/post/sim_output.py
@@ -356,7 +356,7 @@ class OpenMCSimOutput(AbstractSimOutput):
                 statepoint_found = True
         return statepoint_found
     
-    def _prep_tally(self, filter_lookup, tally: pd.DataFrame) -> None:
+    def _prep_tally(self, filter_lookup: dict[str, str], tally: pd.DataFrame) -> pd.DataFrame:
         '''
         Function to prepare the tally dataframe for JADE formatting, by renaming the columns and sorting by the filters.
         

--- a/src/jade/post/sim_output.py
+++ b/src/jade/post/sim_output.py
@@ -283,7 +283,7 @@ class OpenMCSimOutput(AbstractSimOutput):
         sim_folder: PathLike,
     ) -> None:
         """
-        Class representing all outputs coming from OpenMC run
+        Class representing all outputs coming from OpenMC run excluding Sphere
 
         Parameters
         ----------
@@ -454,7 +454,7 @@ class OpenMCSphereSimOutput(OpenMCSimOutput):
         sim_folder: PathLike,
     ) -> None:
         """
-        Class representing all outputs coming from OpenMC run
+        Class representing all outputs coming from OpenMC Sphere run
 
         Parameters
         ----------

--- a/src/jade/post/sim_output.py
+++ b/src/jade/post/sim_output.py
@@ -355,6 +355,28 @@ class OpenMCSimOutput(AbstractSimOutput):
             if file.startswith("statepoint") and file.endswith(".h5"):
                 statepoint_found = True
         return statepoint_found
+    
+    def _prep_tally(self, filter_lookup, tally: pd.DataFrame) -> None:
+        filters = []
+        new_columns = {}
+        if "cell" in tally.columns:
+            filters.append("cell")
+        if "surface" in tally.columns:
+            filters.append("surface")
+        if "energy high [eV]" in tally.columns:
+            filters.append("energy high [eV]")
+        if "time" in tally.columns:
+            filters.append("time")
+        new_columns = dict(
+            (k, filter_lookup[k]) for k in filters if k in filter_lookup)
+        new_columns["mean"] = filter_lookup["mean"]
+        new_columns["std. dev."] = filter_lookup["std. dev."]
+        sorted_tally = tally.sort_values(filters)
+        sorted_tally = sorted_tally.reset_index(drop=True)
+        sorted_tally = sorted_tally.rename(columns=new_columns)
+        # remove constant columns
+        sorted_tally = _remove_constant_columns(sorted_tally)
+        return sorted_tally
 
     def _create_dataframes(
         self, tallies: dict
@@ -398,29 +420,11 @@ class OpenMCSimOutput(AbstractSimOutput):
             "Error",
         ]
         for id, tally in tallies.items():
-            filters = []
-            new_columns = {}
-            if "cell" in tally.columns:
-                filters.append("cell")
-            if "surface" in tally.columns:
-                filters.append("surface")
-            if "energy high [eV]" in tally.columns:
-                filters.append("energy high [eV]")
-            if "time" in tally.columns:
-                filters.append("time")
-            new_columns = dict(
-                (k, filter_lookup[k]) for k in filters if k in filter_lookup
-            )
-            new_columns["mean"] = filter_lookup["mean"]
-            new_columns["std. dev."] = filter_lookup["std. dev."]
-            sorted_tally = tally.sort_values(filters)
-            sorted_tally = sorted_tally.reset_index(drop=True)
-            sorted_tally = sorted_tally.rename(columns=new_columns)
-            # remove constant columns
-            sorted_tally = _remove_constant_columns(sorted_tally)
+            sorted_tally = self._prep_tally(filter_lookup, tally)
+            
             if "Value" in sorted_tally.columns and "Error" in sorted_tally.columns:
                 sorted_tally["Error"] = sorted_tally["Error"] / sorted_tally["Value"]
-
+            
             tallydata[id] = sorted_tally
             totalbin[id] = None
         return tallydata, totalbin
@@ -442,6 +446,100 @@ class OpenMCSimOutput(AbstractSimOutput):
 
     def _read_code_version(self) -> str | None:
         return self.output.version
+
+
+class OpenMCSphereSimOutput(OpenMCSimOutput):
+    def __init__(
+        self,
+        sim_folder: PathLike,
+    ) -> None:
+        """
+        Class representing all outputs coming from OpenMC run
+
+        Parameters
+        ----------
+        output_path : str | os.PathLike
+            Path to simulation output files
+
+        Returns
+        -------
+        None.
+
+        """
+        _, statefile, volfile = self.retrieve_file(sim_folder)
+        
+        # Retrieving atomic density for normalisation of the DPA, He and T production tallies
+        self.input = omc.OpenMCInputFiles(sim_folder)
+        materials = self.input.geometry.get_all_materials()
+        # There is only one material in the Sphere input so this is hard coded
+        atomic_densities = materials[1].get_nuclide_atom_densities()
+        self.atomic_density = sum(atomic_densities.values())
+
+        self.output = omc.OpenMCStatePoint(statefile, volfile)
+        self._tally_numbers = self.output.tally_numbers
+        self._tally_comments = self.output.tally_comments
+        self._tallydata, self._totalbin = self._process_tally()
+        self.stat_checks = None
+
+        
+    def _create_dataframes(
+        self, tallies: dict
+    ) -> tuple[dict[int, pd.DataFrame], dict[int, pd.DataFrame]]:
+        """
+        Function to create dataframes in JADE format from OpenMC dataframes.
+
+        Parameters
+        ----------
+        tallies : dict
+            Dictionary of OpenMC tally dataframes, indexed by tally number
+
+        Returns
+        -------
+        tallydata : dict[int, pd.DataFrame]
+            Dictionary of JADE formatted tally dataframes, indexed by tally number
+        totalbin : dict[int, None]]
+            Dictionary of JADE formatted total tally values, each are None for OpenMC
+        """
+        tallydata = {}
+        totalbin = {}
+        filter_lookup = {
+            "cell": "Cells",
+            "surface": "Segments",
+            "energy high [eV]": "Energy",
+            "time": "Time",
+            "mean": "Value",
+            "std. dev.": "Error",
+        }
+        columns = [
+            "Cells",
+            "User",
+            "Segments",
+            "Cosine",
+            "Energy",
+            "Time",
+            "Cor C",
+            "Cor B",
+            "Cor A",
+            "Value",
+            "Error",
+        ]
+        for id, tally in tallies.items():
+            sorted_tally = self._prep_tally(filter_lookup, tally)
+
+            # If tally is Sphere, and is tally 14,24,34 then need to normalise by atomic density
+            # Need to generate atomic density for a given Sphere input
+            if id in [14, 24, 34]:
+                sorted_tally["Value"] = sorted_tally["Value"] / self.atomic_density
+                sorted_tally["Error"] = sorted_tally["Error"] / self.atomic_density
+            else:
+                pass
+            
+            if "Value" in sorted_tally.columns and "Error" in sorted_tally.columns:
+                sorted_tally["Error"] = sorted_tally["Error"] / sorted_tally["Value"]
+            
+            tallydata[id] = sorted_tally
+            totalbin[id] = None
+        return tallydata, totalbin
 
 
 def _remove_constant_columns(df: pd.DataFrame) -> pd.DataFrame:

--- a/src/jade/resources/default_cfg/benchmarks_pp/raw/openmc/Sphere.yaml
+++ b/src/jade/resources/default_cfg/benchmarks_pp/raw/openmc/Sphere.yaml
@@ -27,3 +27,12 @@ Photon heating:
 Leakage neutron flux:
   concat_option: no_action
   12: [[scale, {"factor": 3.182462327E-3}], [delete_cols, *del_cols]]
+He ppm production:
+  concat_option: no_action
+  14: [[no_action, {}]]
+T production:
+  concat_option: no_action
+  24: [[no_action, {}]]
+DPA production:
+  concat_option: no_action
+  34: [[no_action, {}]]

--- a/tests/dummy_structure/simulations/_openmc_-_FENDL 3.2b_/Sphere/Sphere_m101/geometry.xml
+++ b/tests/dummy_structure/simulations/_openmc_-_FENDL 3.2b_/Sphere/Sphere_m101/geometry.xml
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<geometry>
+  <cell id="1" material="void" region="-1" universe="0"/>
+  <cell id="2" material="1" region="1 -2" universe="0"/>
+  <cell id="3" material="void" region="2 -3" universe="0"/>
+  <cell id="4" material="void" region="3" universe="0"/>
+  <surface id="1" type="sphere" coeffs="0.0 0.0 0.0 5.0"/>
+  <surface id="2" type="sphere" coeffs="0.0 0.0 0.0 50.0"/>
+  <surface id="3" type="sphere" boundary="vacuum" coeffs="0.0 0.0 0.0 50.01"/>
+</geometry>

--- a/tests/dummy_structure/simulations/_openmc_-_FENDL 3.2b_/Sphere/Sphere_m101/materials.xml
+++ b/tests/dummy_structure/simulations/_openmc_-_FENDL 3.2b_/Sphere/Sphere_m101/materials.xml
@@ -1,0 +1,7 @@
+<?xml version='1.0' encoding='utf-8'?>
+<materials>
+  <material id="1" name="M1">
+    <density value="0.0708" units="g/cc"/>
+    <nuclide name="H1" ao="100.0"/>
+  </material>
+</materials>

--- a/tests/post/test_sim_output.py
+++ b/tests/post/test_sim_output.py
@@ -55,6 +55,7 @@ def openmc_sphere_sim_output() -> OpenMCSphereSimOutput:
 class TestOpenMCSimoutput:
     pass
 
+@pytest.mark.skipif(not OMC_AVAIL, reason="OpenMC is not available")
 class TestOpenMCSphereSimOutput:
     def test_openmc_sphere_tallydata(self, openmc_sphere_sim_output):
         assert isinstance(openmc_sphere_sim_output.tallydata, dict)

--- a/tests/post/test_sim_output.py
+++ b/tests/post/test_sim_output.py
@@ -8,7 +8,7 @@ import pytest
 
 import tests.dummy_structure as dummy_struct
 from jade.helper.__optionals__ import OMC_AVAIL
-from jade.post.sim_output import MCNPSimOutput, OpenMCSimOutput
+from jade.post.sim_output import MCNPSimOutput, OpenMCSimOutput, OpenMCSphereSimOutput
 
 SIMULATION_FOLDER = files(dummy_struct).joinpath("simulations")
 
@@ -45,7 +45,23 @@ class TestMCNPSimOutput:
             isinstance(comment, str) for comment in mcnp_sim_output.tally_comments
         )
 
+@pytest.fixture
+def openmc_sphere_sim_output() -> OpenMCSphereSimOutput:
+    folder = Path(SIMULATION_FOLDER, "_openmc_-_FENDL 3.2b_", "Sphere", "Sphere_m101")
+    # Create dummy files for OpenMC Sphere
+    return OpenMCSphereSimOutput(folder)
 
 @pytest.mark.skipif(not OMC_AVAIL, reason="OpenMC is not available")
 class TestOpenMCSimoutput:
     pass
+
+class TestOpenMCSphereSimOutput:
+    def test_openmc_sphere_tallydata(self, openmc_sphere_sim_output):
+        assert isinstance(openmc_sphere_sim_output.tallydata, dict)
+        assert all(
+            isinstance(df, pd.DataFrame) for df in openmc_sphere_sim_output.tallydata.values()
+        )
+
+    def test_atomic_density(self, openmc_sphere_sim_output):
+        assert isinstance(openmc_sphere_sim_output.atomic_density, float)
+        assert openmc_sphere_sim_output.atomic_density == pytest.approx(0.042305713026896896)


### PR DESCRIPTION
This pull request includes various changes with the combined effort to implement additional tallies into the OpenMC Sphere benchmarks.

To make the new tallies comparible to the MCNP results they must be normalised by the atomic density of the material. It would be impractical to implement this in the raw.yaml file for the OpenMC sphere benchmark for ever instance of the Sphere benchmark. 
Instead, the atomic densities are being retrieved from the geometry.xml file and being folded into the tally results. 

To facilitate this the following changes have been made:
-  I have added the new tallies to the OpenMC Sphere.yaml file
- Implemented a new class, OpenMCSphereSimOutput, that inherits from OpenMCSimOutput. 
      - self.atomic_density is retrieved in _innit_ function
      - Differing logic in create_dataframe function that divides by atomic density
- Bugfix that prevented any openmc score 'damage-energy' to be converted to MeV as intended
- Some unit test have been added.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for OpenMC Sphere simulation outputs with automatic atomic-density normalization for specific tallies
  * Added Sphere benchmark outputs for He ppm, T production, and DPA production

* **Bug Fixes**
  * Improved detection of energy-based tallies to ensure correct eV→MeV normalization

* **Tests**
  * Added fixtures and tests validating Sphere output processing and atomic-density calculations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JADE-V-V/JADE/pull/531?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->