### PR TITLE
Avoid scalar divide warnings raised when generating raw .csv files

### DIFF
--- a/src/jade/post/manipulate_tally.py
+++ b/src/jade/post/manipulate_tally.py
@@ -167,7 +167,9 @@ def groupby(tally: pd.DataFrame, by: str, action: str) -> pd.DataFrame:
         # Valid both for sum and mean
         error = pd.Series(
             np.sqrt(((tally["Error"] * tally["Value"]) ** 2).sum())
-            / tally["Value"].sum(),
+            / tally["Value"].sum()
+            if tally["Value"].sum() != 0
+            else 0,
             name="Error",
         )
     else:

--- a/src/jade/post/manipulate_tally.py
+++ b/src/jade/post/manipulate_tally.py
@@ -181,6 +181,8 @@ def groupby(tally: pd.DataFrame, by: str, action: str) -> pd.DataFrame:
             # Valid both for sum and mean
             err = (
                 np.sqrt(np.sum((subset_error * subset_value) ** 2)) / subset_value.sum()
+                if subset_value.sum() != 0
+                else 0
             )
             rows.append(err)
         error = pd.Series(rows, name="Error")

--- a/tests/post/test_manipulate_tally.py
+++ b/tests/post/test_manipulate_tally.py
@@ -18,9 +18,8 @@ from src.jade.post.manipulate_tally import (
     divide_by_bin,
     format_decimals,
     gaussian_broadening,
-    volume,
-    mass,
     groupby,
+    mass,
     no_action,
     no_concat,
     ratio,
@@ -30,6 +29,7 @@ from src.jade.post.manipulate_tally import (
     subtract_tallies,
     sum_tallies,
     tof_to_energy,
+    volume,
 )
 
 
@@ -200,27 +200,28 @@ def test_add_column_with_dict():
     pd.testing.assert_frame_equal(result, expected)
 
 
-def test_groupby():
+def test_groupby(recwarn):
     data = {
-        "Energy": [1, 1, 2, 2],
-        "Value": [1, 2, 3, 4],
-        "Error": [0.1, 0.2, 0.3, 0.1],
+        "Energy": [1, 1, 2, 2, 3, 3],
+        "Value": [1, 2, 3, 4, 0, 0],
+        "Error": [0.1, 0.2, 0.3, 0.1, 0.0, 0.0],
     }
     df = pd.DataFrame(data)
+
     result = groupby(df.copy(), "Energy", "sum")
-    assert (result["Value"] == [3, 7]).all()
+    assert (result["Value"] == [3, 7, 0]).all()
     assert (
         result["Error"].iloc[0]
         == np.sqrt((0.1 * 1) ** 2 + (0.2 * 2) ** 2) / result["Value"].iloc[0]
     )
     result = groupby(df.copy(), "Energy", "mean")
-    assert (result["Value"] == [1.5, 3.5]).all()
+    assert (result["Value"] == [1.5, 3.5, 0.0]).all()
     result = groupby(df.copy(), "Energy", "max")
-    assert (result["Value"] == [2, 4]).all()
-    assert (result["Error"] == [0.2, 0.1]).all()
+    assert (result["Value"] == [2, 4, 0]).all()
+    assert (result["Error"] == [0.2, 0.1, 0.0]).all()
     result = groupby(df.copy(), "Energy", "min")
-    assert (result["Value"] == [1, 3]).all()
-    assert (result["Error"] == [0.1, 0.3]).all()
+    assert (result["Value"] == [1, 3, 0]).all()
+    assert (result["Error"] == [0.1, 0.3, 0.0]).all()
     result = groupby(df.copy(), "all", "sum")
     assert result["Value"].iloc[0] == 10
     assert (
@@ -229,6 +230,7 @@ def test_groupby():
         / result["Value"].iloc[0]
     )
     assert len(result) == 1
+    assert len(recwarn) == 0  # If any warning is raised, the test fails
 
 
 def test_delete_cols():


### PR DESCRIPTION
This pull requests implements a solution for the warning repeatedly raised when generating raw results:
<img width="659" height="28" alt="image" src="https://github.com/user-attachments/assets/9c44b7e0-c6f2-4f1e-a5b3-c47b1702e215" />

The warning was traced back to the _group_by_ function in the _manipulate_tally.py_ file. Accordingly, the following modifications were implemented:
- If the denominator of the division which causes the warning is 0, instead of doing the error propagation, the value 0 is assigned to the corresponding error.
- The test function of _group_by_ was modified to check for any raised warnings. If any warnings are raised, the test fails.

No additional dependencies were introduced.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a division by zero error in grouping operations when calculating error values with zero sums, now properly returning zero instead.

* **Tests**
  * Enhanced test coverage with expanded datasets across additional energy groups and added validation to ensure no warnings are emitted during grouping operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JADE-V-V/JADE/pull/533?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->