### PR TITLE
Simple tokamak histogram plots

### DIFF
--- a/docs/source/dev/pp_gallery.rst
+++ b/docs/source/dev/pp_gallery.rst
@@ -286,6 +286,10 @@ These are the extra ``plot_args`` that this type of plot can accept:
   by default it is set to 20.
 * ``log``: if True, the y-axis is set to log scale. Default is False. The code also analyses the data to be plotted
   and if the values span in less than 2 order of magnitude the log scale is not applied.
+* ``shorten_x_name``: this type of plots are often categorical. In the event of using the 
+cases as x axis, the long names of the benchmark runs can become problematic. This option
+will split the name of the benchmark run on the '_' symbols and retain only the last N chunks
+where N is the specified *shorten_x_name* value.
 
 Waves plot (waves)
 ------------------

--- a/src/jade/post/plotter.py
+++ b/src/jade/post/plotter.py
@@ -872,9 +872,11 @@ class BarPlot(Plot):
         if self.cfg.plot_args is not None:
             log = self.cfg.plot_args.get("log", False)
             maxgroups = self.cfg.plot_args.get("max_groups", 20)
+            shorten_x_name = self.cfg.plot_args.get("shorten_x_name", False)
         else:
             log = False
             maxgroups = 20
+            shorten_x_name = False
 
         # Override log parameter if variation is low on y axis
         if log:
@@ -888,7 +890,7 @@ class BarPlot(Plot):
 
         # Check if the data is higher than max
         labels = self.data[0][1][self.cfg.x].values
-        nrows = len(labels) // maxgroups + 1
+        nrows = (len(labels)-1) // maxgroups + 1
         if nrows == 1:
             nlabels = len(labels)
         else:
@@ -936,6 +938,9 @@ class BarPlot(Plot):
 
         # By default seaborn is going to put the y label. delete all y label in axes
         for ax in axes:
+            # change the label text
+            if shorten_x_name:
+                _shorten_x_name(ax, shorten_x_name)
             ax.set_ylabel("")
             ax.set_xlabel("")
             _rotate_ticks(ax)

--- a/src/jade/resources/default_cfg/benchmarks_pp/atlas/Simple_Tokamak.yaml
+++ b/src/jade/resources/default_cfg/benchmarks_pp/atlas/Simple_Tokamak.yaml
@@ -67,5 +67,91 @@ Photon spectrum in PF coils [175 group]:
     subcases: ["Cells", ["PF_coil_1", "PF_coil_2", "PF_coil_3", "PF_coil_4"]]
     scale_subcases: true
     style : 'step'
+Neutron Heating in PF coils:
+  results:
+    - Neutron nuclear heating in PF coils
+  plot_type: barplot
+  title: Neutron heating in PF coils 
+  x_label: "Cells"
+  y_labels: "Energy $\\left[\\mathrm{MeV}\\right]$"
+  x: Cells
+  y: Value
+  expand_runs: false
+  plot_args:
+    show_error: false
+    show_CE: false
+    log: False
+Neutron Heating in blanket:
+  results:
+    - Neutron nuclear heating in blanket
+  plot_type: barplot
+  title: Neutron heating in blanket
+  x_label: "Cells"
+  y_labels: "Energy $\\left[\\mathrm{MeV}\\right]$"
+  x: Cells
+  y: Value
+  expand_runs: false
+  plot_args:
+    max_groups: 20
+    log: False
+    shorten_x_name: 3
+Neutron Heating in VV:
+  results:
+    - Neutron nuclear heating in VV
+  plot_type: barplot
+  title: Neutron heating in VV 
+  x_label: "Cells"
+  y_labels: "Energy $\\left[\\mathrm{MeV}\\right]$"
+  x: Cells
+  y: Value
+  expand_runs: false
+  plot_args:
+    show_error: false
+    show_CE: false
+    log: False
+#
+Photon Heating in PF coils:
+  results:
+    - Photon nuclear heating in PF coils
+  plot_type: barplot
+  title: Photon heating in PF coils 
+  x_label: "Cells"
+  y_labels: "Energy $\\left[\\mathrm{MeV}\\right]$"
+  x: Cells
+  y: Value
+  expand_runs: false
+  plot_args:
+    show_error: false
+    show_CE: false
+    log: False
+Photon Heating in blanket:
+  results:
+    - Photon nuclear heating in blanket
+  plot_type: barplot
+  title: Photon heating in blanket
+  x_label: "Cells"
+  y_labels: "Energy $\\left[\\mathrm{MeV}\\right]$"
+  x: Cells
+  y: Value
+  expand_runs: false
+  plot_args:
+    max_groups: 20
+    log: False
+    shorten_x_name: 3
+#
+Photon Heating in VV:
+  results:
+    - Photon nuclear heating in VV
+  plot_type: barplot
+  title: Photon heating in VV 
+  x_label: "Cells"
+  y_labels: "Energy $\\left[\\mathrm{MeV}\\right]$"
+  x: Cells
+  y: Value
+  expand_runs: false
+  plot_args:
+    show_error: false
+    show_CE: false
+    log: False
 
 


### PR DESCRIPTION
This pull request includes the changes required to implement histogram plots into the atlas file of the Simple_Tokamak benchmark.

The following changes were made:
- Implementation of 'shorten_x_name', in order to generate a plot that looked sensible. Previously the second subplot was cutting off the x_labels.
- Updated the documentation to reflect the addition of shorten_x_name to the the plot_ars for the bar plot
- line 893, was added so that if the total number of bins is exactly divisible by max_groups, previously it would have created an additional subplot that was empty.
- Updated the atlas yaml file for the simple tokamak to include these new plots.
<img width="1125" height="1025" alt="image" src="https://github.com/user-attachments/assets/2c63933a-faf9-47dc-b58e-b51866e04902" />

