### PR TITLE
port to f4enix v1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "matplotlib",
     "aspose-words",
     "requests",
-    "f4enix >= 0.19.0",
+    "f4enix >= 1.0.0",
     "pyyaml",
     "seaborn",
     "python-gitlab"

--- a/src/jade/helper/openmc.py
+++ b/src/jade/helper/openmc.py
@@ -18,7 +18,7 @@ import pandas as pd
 
 if TYPE_CHECKING:
     from f4enix.input.libmanager import LibManager
-    from f4enix.input.materials import MatCardsList, Material, SubMaterial, Zaid
+    from f4enix.input.materials import MatCardsList, Material, Zaid
 
     from jade.helper.aux_functions import PathLike
 
@@ -256,8 +256,8 @@ class OpenMCInputFiles:
 
         Parameters
         ----------
-        talllies : str
-            path to geometry input xml
+        tallies : str
+            path to tallies input xml
 
         Returns
         -------
@@ -293,7 +293,7 @@ class OpenMCInputFiles:
 
         Parameters
         ----------
-        zaid : str
+        zaid : Zaid
             Zaid to be added to the OpenMC material
         openmc_material : openmc.Material
             An instance of the OpenMC Material class representing the material used in the simulation.
@@ -302,7 +302,7 @@ class OpenMCInputFiles:
         -------
         None
         """
-        nuclide = zaid.get_fullname(libmanager).replace("-", "")
+        nuclide = zaid.fullname
         # if no istope number is in the nuclide, a zero needs to be added
         if PAT_DIGITS.search(nuclide) is None:
             nuclide = nuclide + "0"
@@ -311,33 +311,9 @@ class OpenMCInputFiles:
         else:
             openmc_material.add_nuclide(nuclide, 100 * abs(zaid.fraction), "ao")
 
-    def submat_to_openmc(
-        self,
-        submaterial: SubMaterial,
-        openmc_material: openmc.Material,
-        libmanager: LibManager,
+    def mat_to_openmc(
+        self, material: Material, libmanager: LibManager, density: float
     ) -> None:
-        """Handle submaterials in OpenMC
-
-        Parameters
-        ----------
-        submaterial : SubMaterial
-            An instance of the SubMaterial class representing a subcomponent of a material.
-            It contains elements, each of which has ZAIDs (nuclide identifiers).
-        openmc_material : openmc.Material
-            An instance of the OpenMC Material class representing the material used in the simulation.
-        libmanager : libmanager.LibManager
-            An instance of the LibManager class responsible for managing external libraries.
-
-        Returns
-        -------
-        None
-        """
-        for elem in submaterial.elements:
-            for zaid in elem.zaids:
-                self.zaid_to_openmc(zaid, openmc_material, libmanager)
-
-    def mat_to_openmc(self, material: Material, libmanager: LibManager) -> None:
         """Convert a material to an OpenMC material and handle its submaterials.
 
         Parameters
@@ -346,6 +322,8 @@ class OpenMCInputFiles:
             An instance of the Material class representing the material to be converted.
         libmanager : LibManager
             An instance of the LibManager class responsible for managing external libraries.
+        density : float
+            The density to be assigned to the material.
 
         Returns
         -------
@@ -353,35 +331,40 @@ class OpenMCInputFiles:
         """
         matid = int(re.sub("[^0-9]", "", str(material.name)))
         matname = str(material.name)
-        matdensity = abs(material.density)
-        if material.density < 0:
+        matdensity = abs(density)
+        if density < 0:
             density_units = "g/cc"
         else:
             raise ValueError("Density should be provided negative (mass)")
         openmc_material = openmc.Material(matid, name=matname)
         openmc_material.set_density(density_units, matdensity)
-        if material.submaterials is not None:
-            for submaterial in material.submaterials:
-                self.submat_to_openmc(submaterial, openmc_material, libmanager)
+        for zaid in material.zaids:
+            self.zaid_to_openmc(zaid, openmc_material, libmanager)
+
         self.materials.append(openmc_material)
 
-    def matlist_to_openmc(self, matlist: MatCardsList, libmanager: LibManager) -> None:
+    def matlist_to_openmc(
+        self, matlist: MatCardsList, libmanager: LibManager, densities: dict[str, float]
+    ) -> None:
         """Convert a list of materials to OpenMC materials and load the geometry.
 
         Parameters
         ----------
         matlist : MatCardsList
-            A list of Material instances to be converted. Each material should have the necessary
+            A list of Material instances to be converted. Each material should have
+            the necessary
             attributes required by the mat_to_openmc method.
         libmanager : LibManager
             An instance of the LibManager class responsible for managing external libraries.
+        densities : dict[str, float]
+            A dictionary mapping material names to their respective densities.
 
         Returns
         -------
         None
         """
         for material in matlist:
-            self.mat_to_openmc(material, libmanager)
+            self.mat_to_openmc(material, libmanager, densities[material.name])
         self.load_geometry(os.path.join(self.path, "geometry.xml"), self.materials)
 
     def write(self, path: PathLike) -> None:
@@ -576,7 +559,7 @@ class OpenMCStatePoint:
                 try:
                     particle_filter = tally.find_filter(openmc.ParticleFilter)
                 except ValueError:
-                    particle_filter =  None
+                    particle_filter = None
                 cell_filter = tally.find_filter(openmc.CellFilter)
                 if particle_filter and cell_filter:
                     if photon_cell_filter == cell_filter:

--- a/src/jade/run/benchmark.py
+++ b/src/jade/run/benchmark.py
@@ -695,7 +695,7 @@ class SphereBenchmarkRun(BenchmarkRun):
         # benchmarks folder
         matpath = Path(Path(self.benchmark_templates_root).parent, "TypicalMaterials")
         inpmat = ipt.Input.from_input(matpath)
-        materials = inpmat.materials
+        materials = inpmat.mat_section
 
         # init a libmanager to get the zaid names
         lm = LibManager()
@@ -850,7 +850,7 @@ class SphereSDDRBenchmarkRun(SphereBenchmarkRun):
         # benchmarks folder
         matpath = Path(Path(self.benchmark_templates_root).parent, "TypicalMaterials")
         inpmat = ipt.Input.from_input(matpath)
-        materials = inpmat.materials
+        materials = inpmat.mat_section
 
         # init a libmanager to get the zaid names
         lm = LibManager()

--- a/src/jade/run/input.py
+++ b/src/jade/run/input.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 from f4enix.input.d1suned import IrradiationFile, Reaction, ReactionFile
 from f4enix.input.libmanager import LibManager
-from f4enix.input.materials import MatCardsList, Material, SubMaterial, Zaid
+from f4enix.input.materials import MatCardsList, Material, Zaid
 from f4enix.input.MCNPinput import D1S_Input
 from f4enix.input.MCNPinput import Input as MCNPInput
 from f4enix.core.irradiation import Nuclide
@@ -137,7 +137,6 @@ class InputMCNP(Input):
         if self.lib.suffix is None:
             raise ValueError("suffix must be provided for MCNP libraries")
         self.inp.translate(self.lib.suffix, self.lm)
-        self.inp.update_zaidinfo(self.lm)
 
     def _write(self, output_folder: PathLike):
         # write the new input
@@ -183,10 +182,9 @@ class InputMCNPSphere(InputMCNP):
         matlist = MatCardsList([material])
 
         # adjourn density and material
-        self.inp.materials = matlist
+        self.inp.mat_section = matlist
         sphere_cell = self.inp.cells["2"]
-        sphere_cell.set_d(density)
-        sphere_cell.lines = sphere_cell.card()
+        sphere_cell.density = float(density)
 
     def _get_material(self, zaid: str | Material) -> Material:
         if isinstance(zaid, Material):
@@ -202,10 +200,9 @@ class InputMCNPSphere(InputMCNP):
                 zaidlib = "31c"
             else:
                 zaidlib = self.lib.suffix
-            zaidob = Zaid(1, zaid[:-3], zaid[-3:], zaidlib)
+            zaidob = Zaid(1, Nuclide.from_int_string(zaid + "." + zaidlib))
             name, formula = self.lm.get_zaidname(zaid)
-            submat = SubMaterial("M1", [zaidob], header="C " + name + " " + formula)
-            material = Material([zaidob], None, "M1", submaterials=[submat])
+            material = Material("M1", [zaidob], header="C " + name + " " + formula)
             # override the input name
             self._name = f"{self.name}_{zaid}_{formula}"
 
@@ -276,10 +273,9 @@ class InputOpenMcSphere(InputOpenMC):
 
     def _assign_zaid_material(self, zaid: str | Material, density: str):
         material = self._get_material(zaid)
-        material.density = float(density)
         materials = MatCardsList([material])
         # Assign material
-        self.inp.matlist_to_openmc(materials, self.lm)
+        self.inp.matlist_to_openmc(materials, self.lm, {material.name: float(density)})
 
     def _get_material(self, zaid: str | Material) -> Material:
         if isinstance(zaid, Material):
@@ -291,10 +287,9 @@ class InputOpenMcSphere(InputOpenMC):
             self._name = f"{self.name}_{truename}"
         else:
             # zaid suffix used here is irrelevant, as it is not used in the OpenMC
-            zaidob = Zaid(1, zaid[:-3], zaid[-3:], "00c")
+            zaidob = Zaid(1, Nuclide.from_int_string(zaid + ".00c"))
             name, formula = self.lm.get_zaidname(zaid)
-            submat = SubMaterial("M1", [zaidob], header="C " + name + " " + formula)
-            material = Material([zaidob], None, "M1", submaterials=[submat])
+            material = Material("M1", [zaidob], header="C " + name + " " + formula)
             # override the input name
             self._name = f"{self.name}_{zaid}_{formula}"
 
@@ -386,7 +381,6 @@ class InputD1S(Input):
 
     def translate(self):
         self.inp.smart_translate(self.lib.suffix, self.lib.transport_suffix, self.lm)
-        self.inp.update_zaidinfo(self.lm)
 
     def _write(self, output_folder: PathLike):
         # write the new input

--- a/tests/run/test_input.py
+++ b/tests/run/test_input.py
@@ -68,10 +68,9 @@ class TestIputMCNP:
 
         # Check if the file was written correctly
         read_inp = ipt.Input.from_input(Path(tmpdir).joinpath("Oktavian_Al.i"))
-        nps_lines = read_inp.other_data["NPS"].lines
-        assert len(nps_lines) == 1
-        assert nps_lines[0][:6] == "NPS 10"
-        assert read_inp.materials["M1"].submaterials[0].zaidList[0].library == "31c"
+        nps_line = read_inp.other_data["NPS"].text
+        assert nps_line[:6] == "NPS 10"
+        assert read_inp.mat_section["M1"].zaids[0].library == "31c"
         assert os.path.exists(Path(tmpdir).joinpath("wwinp"))
 
 
@@ -114,10 +113,9 @@ class TestInputMCNPSphere:
 
         # Check if the file was written correctly
         read_inp = ipt.Input.from_input(Path(tmpdir).joinpath("Sphere_1001_H-1.i"))
-        nps_lines = read_inp.other_data["NPS"].lines
-        assert len(nps_lines) == 1
-        assert nps_lines[0][:6] == "NPS 10"
-        assert read_inp.materials["M1"].submaterials[0].zaidList[0].library == "31c"
+        nps_line = read_inp.other_data["NPS"].text
+        assert nps_line[:6] == "NPS 10"
+        assert read_inp.mat_section["M1"].zaids[0].library == "31c"
 
 
 @pytest.mark.skipif(not OMC_AVAIL, reason="OpenMC not available")


### PR DESCRIPTION
f4enix package was recently updated to v1 which breaks retrocompatibility. Small fixes are needed in JADE to account for this

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated sphere input generation and material handling for compatibility with the latest supported F4Enix API.
  - Improved OpenMC material conversion, including more reliable nuclide and density handling.
  - Corrected material recovery during benchmark workflows.
  - Fixed a documentation typo and minor formatting issue in OpenMC processing.

- **Tests**
  - Updated input-generation checks to reflect the current material and output structures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->